### PR TITLE
feat: add claude/ folder with starter configs, rules, hooks, and skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Configuration files and workflow examples for AI coding tools.
 - [awesome-cursorrules](https://github.com/PatrickJS/awesome-cursorrules) - Curated list of Cursor rule files.
 - [Claude Code Memory Files](https://docs.anthropic.com/en/docs/claude-code/memory) - Guide to CLAUDE.md and project memory.
 - [CursorDirectory](https://cursor.directory) - Community-shared Cursor rules and configurations.
+- [Claude Code Starter Configs](claude/) - Ready-to-use CLAUDE.md, rules, hooks, and skills for Claude Code projects.
 - [dotfiles](https://dotfiles.github.io) - Guide to managing dotfiles including agent configurations.
 
 ## Knowledge Graphs and Memory

--- a/claude/AGENTS.md
+++ b/claude/AGENTS.md
@@ -1,0 +1,122 @@
+# AGENTS.md -- Agent Orchestration Guide
+#
+# This guide defines principles and patterns for multi-agent workflows
+# in Claude Code. Adapt the agent definitions to your project's needs.
+
+## Core Principles
+
+### Plan Before Execute
+
+Break complex tasks into discrete steps before writing any code. Identify dependencies between steps, surface ambiguities early, and confirm the approach before committing to implementation. A 5-minute plan prevents a 2-hour dead end.
+
+### Test-Driven Development
+
+Write tests first. Define expected behavior before implementation. Tests serve as both specification and verification -- they clarify what "done" means and catch regressions immediately. Run the full test suite before declaring any task complete.
+
+### Security First
+
+Never commit secrets, credentials, API keys, or tokens. Validate all external inputs. Apply the principle of least privilege. Default to secure configurations. When in doubt, restrict access and require explicit opt-in rather than opt-out.
+
+### Immutability and Pure Functions
+
+Prefer pure functions that take inputs and return outputs without side effects. Use immutable data structures where practical. Isolate stateful operations (I/O, database, network) at the boundaries of your system. This makes code easier to test, reason about, and parallelize.
+
+### Agent-First Delegation
+
+Delegate complex, context-heavy, or parallelizable tasks to subagents. The main agent should orchestrate and make decisions; subagents should execute focused work. This preserves the main context window for high-level reasoning.
+
+---
+
+## Agent Orchestration Patterns
+
+### When to Delegate to Subagents
+
+- **Research tasks**: Exploring unfamiliar codebases, reading documentation, investigating dependencies
+- **Parallel workstreams**: Independent changes across multiple files or modules
+- **Context-heavy analysis**: Tasks that require reading many files but produce a concise result
+- **Repetitive operations**: Applying the same transformation across many locations
+
+### How to Compose Agents
+
+Use agents as specialized roles, not general-purpose assistants:
+
+- **Explorer** (subagent_type=Explore): Deep codebase search, dependency tracing, architecture mapping
+- **Planner**: Task decomposition, dependency analysis, risk identification
+- **Implementer**: Focused code changes scoped to a single concern
+- **Reviewer**: Post-implementation quality and correctness checks
+
+### Context Management Across Handoffs
+
+When delegating to subagents or resuming work:
+
+- Pass explicit context: file paths, function names, architectural decisions made so far
+- Include the "why" alongside the "what" -- decisions without rationale get revisited unnecessarily
+- Summarize key constraints: what has been tried, what failed, what must not change
+- Request structured output from subagents (file lists, decision logs) for easy consumption
+
+---
+
+## Agent Definitions
+
+The following four agents are universally applicable across project types. Add project-specific agents as needed.
+
+### 1. Planner
+
+**Role**: Analyze tasks, create implementation plans, identify risks and dependencies.
+
+**When to invoke**: At the start of any non-trivial task, before writing code.
+
+**Responsibilities**:
+- Decompose the task into ordered, testable steps
+- Identify files that need to change and potential side effects
+- Flag ambiguities or missing requirements
+- Estimate blast radius of proposed changes
+- Produce a clear plan that another agent (or human) can execute
+
+**Output format**: Numbered steps with file paths, rationale for key decisions, and a list of open questions.
+
+### 2. Reviewer
+
+**Role**: Review code changes for correctness, style adherence, and maintainability.
+
+**When to invoke**: After implementation, before committing.
+
+**Responsibilities**:
+- Verify changes match the stated intent and do not introduce regressions
+- Check adherence to project conventions (naming, structure, patterns)
+- Identify missing tests or edge cases
+- Flag unnecessary complexity or over-engineering
+- Confirm no debug artifacts, commented-out code, or TODO items slipped in
+
+**Output format**: List of findings categorized as blocking (must fix), warning (should fix), or suggestion (consider fixing).
+
+### 3. Security Reviewer
+
+**Role**: Focused security audit of code changes.
+
+**When to invoke**: For any changes involving authentication, authorization, user input handling, data storage, or external service integration.
+
+**Responsibilities**:
+- Check for OWASP Top 10 vulnerabilities (injection, XSS, CSRF, etc.)
+- Scan for hardcoded secrets, credentials, or API keys
+- Verify input validation and output encoding at system boundaries
+- Review access control logic for privilege escalation paths
+- Check dependency versions for known vulnerabilities
+- Confirm sensitive data is not logged or exposed in error messages
+
+**Output format**: Severity-ranked findings (critical, high, medium, low) with specific file locations and remediation guidance.
+
+### 4. Doc Updater
+
+**Role**: Keep documentation in sync with code changes.
+
+**When to invoke**: After any change that affects public APIs, configuration, setup steps, or architectural decisions.
+
+**Responsibilities**:
+- Update README, CHANGELOG, and inline documentation to reflect changes
+- Ensure code examples in docs actually work
+- Update configuration references when defaults or options change
+- Add migration notes for breaking changes
+- Verify links and cross-references remain valid
+
+**Output format**: List of documentation files updated, with a summary of what changed and why.

--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -1,0 +1,114 @@
+# CLAUDE.md -- Project Memory Template
+#
+# This is a starter template. Copy it to your project root (or .claude/CLAUDE.md)
+# and replace every bracketed placeholder with your project's specifics.
+# Claude Code reads this file at session start to understand your project.
+
+# Project Overview
+
+[Brief description of your project: what it does, who it serves, and why it exists.]
+
+## Tech Stack
+
+[List your languages, frameworks, databases, and key dependencies. Example:]
+
+- Language: [e.g., TypeScript, Python, Rust]
+- Framework: [e.g., Next.js, FastAPI, Actix]
+- Database: [e.g., PostgreSQL, SQLite, Redis]
+- Package Manager: [e.g., pnpm, uv, cargo]
+- Runtime: [e.g., Node 22, Python 3.12, Rust 1.80]
+
+## Architecture
+
+[Describe your project structure and key patterns. Example:]
+
+```
+src/
+  core/       -- Business logic
+  api/        -- HTTP handlers / routes
+  db/         -- Database access layer
+  lib/        -- Shared utilities
+tests/        -- Test suites
+```
+
+[Note any architectural patterns: monorepo vs single package, layered architecture,
+event-driven, microservices, etc.]
+
+## Key Commands
+
+[List the commands you use daily. Example:]
+
+```bash
+# Development
+[your-dev-command]          # Start dev server
+
+# Testing
+[your-test-command]         # Run all tests
+[your-test-watch-command]   # Run tests in watch mode
+
+# Linting and Formatting
+[your-lint-command]         # Lint code
+[your-format-command]       # Format code
+
+# Building
+[your-build-command]        # Production build
+
+# Deployment
+[your-deploy-command]       # Deploy to production
+```
+
+## Development Guidelines
+
+- Follow existing code patterns and conventions in the codebase
+- Write tests for all new functionality
+- Use conventional commits: feat:, fix:, docs:, test:, refactor:, chore:
+- Never commit secrets, credentials, API keys, or .env files
+- Prefer editing existing files over creating new ones
+- Make minimal, focused changes -- do not refactor unrelated code
+- Delete unused code completely; no backwards-compatibility shims
+
+## Testing Strategy
+
+[Describe your testing approach. Example:]
+
+- Unit tests: [location, framework, naming conventions]
+- Integration tests: [location, framework, setup requirements]
+- E2E tests: [location, framework, how to run]
+- Minimum coverage: [e.g., 80% line coverage]
+
+[Note any testing conventions: test file naming, fixture patterns, mocking approach.]
+
+## Code Style
+
+[Language-specific style rules. Example:]
+
+- [Formatting tool and config file, e.g., Prettier with .prettierrc]
+- [Linter and config file, e.g., ESLint with eslint.config.js]
+- [Naming conventions: camelCase for functions, PascalCase for types, etc.]
+- [Import ordering rules]
+- [Max line length, indentation style]
+
+## Important Files
+
+[List key files and their purposes. Example:]
+
+- `[config-file]` -- Main configuration
+- `[entry-point]` -- Application entry point
+- `[schema-file]` -- Database schema / API schema
+- `[ci-config]` -- CI/CD pipeline definition
+
+## Environment Variables
+
+[List required environment variables without actual values. Example:]
+
+- `DATABASE_URL` -- Database connection string
+- `API_KEY` -- External service API key
+- `NODE_ENV` -- Runtime environment (development/production)
+
+## Common Pitfalls
+
+[Document things that tend to trip people up. Example:]
+
+- [Known gotcha #1]
+- [Known gotcha #2]
+- [Anything that requires special handling or workarounds]

--- a/claude/README.md
+++ b/claude/README.md
@@ -1,0 +1,40 @@
+# Claude Code Starter Configs
+
+Curated starter configurations for [Claude Code](https://docs.anthropic.com/en/docs/claude-code), extracted and adapted from battle-tested community sources. These templates give you a solid foundation for configuring Claude Code in any project.
+
+## Primary Source
+
+These configs are adapted from [everything-claude-code](https://github.com/affaan-m/everything-claude-code), a comprehensive collection of Claude Code configurations, patterns, and best practices contributed by the community.
+
+## How to Use
+
+1. **Copy what you need** from this folder into your project
+2. Place `CLAUDE.md` in your project root (or `.claude/CLAUDE.md`)
+3. Place `AGENTS.md` in your project root for agent orchestration guidance
+4. Drop rule files into `.claude/rules/`
+5. Drop hook scripts into `.claude/hooks/`
+6. Drop skill files into `.claude/skills/`
+
+Customize each file for your specific project -- the templates include placeholder sections marked for you to fill in.
+
+## Contents
+
+### `CLAUDE.md` - Project Memory Template
+
+The primary configuration file for Claude Code. This is where you define your project's tech stack, architecture, key commands, coding conventions, and development guidelines. Claude Code reads this file at the start of every session to understand your project context.
+
+### `AGENTS.md` - Agent Orchestration Guide
+
+A guide for structuring multi-agent workflows with Claude Code. Defines core principles (TDD, security-first, plan-before-execute), orchestration patterns for delegating work to subagents, and a set of universally applicable agent definitions (Planner, Reviewer, Security Reviewer, Doc Updater).
+
+### `rules/` - Drop-in Rule Files
+
+Modular rule files for `.claude/rules/`. Each file targets a specific concern (e.g., git conventions, testing requirements, security policies). Rules are automatically loaded by Claude Code when present in the `.claude/rules/` directory.
+
+### `hooks/` - Event-Driven Automation
+
+Hook scripts that run in response to Claude Code events (e.g., pre-commit checks, post-edit validation). These automate repetitive quality gates without manual intervention.
+
+### `skills/` - Slash-Command Skills
+
+Custom skill files that extend Claude Code with project-specific slash commands. Skills encapsulate common workflows (e.g., `/deploy`, `/review`, `/migrate`) into reusable, invocable actions.

--- a/claude/hooks/README.md
+++ b/claude/hooks/README.md
@@ -1,0 +1,101 @@
+# Claude Code Hooks
+
+Hooks are event-driven shell commands that run automatically during Claude Code sessions. They let you enforce guardrails, gather context, and react to agent actions without manual intervention.
+
+## Hook Lifecycle Events
+
+| Event | When it runs | Can block? |
+|-------|-------------|------------|
+| `PreToolUse` | Before a tool call executes | Yes |
+| `PostToolUse` | After a tool call completes | No |
+| `Notification` | When Claude sends a notification | No |
+| `Stop` | When the agent turn ends | Yes |
+| `SubagentStop` | When a subagent turn ends | Yes |
+
+## How to Install
+
+Add hook configurations to `.claude/settings.json` under the `hooks` key. Each event type maps to an array of hook groups, where each group has a `matcher` (regex matched against tool names) and a list of commands to run.
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node .claude/hooks/secret-scanner.js"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node .claude/hooks/after-edit-lint.js"
+          }
+        ]
+      }
+    ],
+    "Notification": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node .claude/hooks/session-start.js"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+## Hook Input
+
+Hooks receive a JSON object on **stdin** containing context about the event:
+
+```json
+{
+  "session_id": "abc-123",
+  "tool_name": "Write",
+  "tool_input": {
+    "file_path": "/path/to/file.js",
+    "content": "file content here..."
+  }
+}
+```
+
+The exact fields vary by event type and tool, but `session_id` and `tool_name` are always present for tool-related events.
+
+## Hook Output
+
+- **PreToolUse** hooks can print JSON to stdout to block or approve a tool call:
+  ```json
+  {"decision": "block", "reason": "Potential secret detected in file content"}
+  ```
+  ```json
+  {"decision": "approve", "reason": "Content looks safe"}
+  ```
+  If a PreToolUse hook exits with code 0 and produces no stdout, the tool call proceeds normally.
+
+- **PostToolUse / Notification** hooks typically write informational output to **stderr**. Their stdout is not used for decisions.
+
+- A non-zero exit code from any hook is treated as an error and reported to the user.
+
+## Hooks in This Directory
+
+| File | Event | Purpose |
+|------|-------|---------|
+| `secret-scanner.js` | PreToolUse | Blocks file writes that contain leaked secrets |
+| `session-start.js` | Notification | Detects project environment and logs context |
+| `after-edit-lint.js` | PostToolUse | Warns about debug statements and TODO comments after edits |
+
+## Official Documentation
+
+Full details on the hooks system: https://docs.anthropic.com/en/docs/claude-code/hooks

--- a/claude/hooks/after-edit-lint.js
+++ b/claude/hooks/after-edit-lint.js
@@ -1,0 +1,100 @@
+// PostToolUse hook: checks edited files for common issues after writes.
+// Outputs warnings to stderr -- does not block anything.
+
+const fs = require("fs");
+const path = require("path");
+
+const DEBUG_PATTERNS = [
+  { pattern: /console\.log\s*\(\s*["'`](?:debug|test|xxx|TODO)/i, label: "debug console.log" },
+  { pattern: /console\.log\s*\(\s*["'`]###/i, label: "debug console.log" },
+  { pattern: /print\s*\(\s*["'](?:debug|test|xxx|TODO)/i, label: "debug print" },
+  { pattern: /debugger\s*;?\s*$/m, label: "debugger statement" },
+];
+
+const TODO_PATTERN = /\b(TODO|FIXME|HACK|XXX)\b/;
+
+const LINTER_SUGGESTIONS = {
+  ".js": "eslint / oxlint",
+  ".jsx": "eslint / oxlint",
+  ".ts": "eslint / oxlint",
+  ".tsx": "eslint / oxlint",
+  ".py": "ruff check",
+  ".rs": "cargo clippy",
+  ".go": "go vet",
+  ".rb": "rubocop",
+};
+
+function readStdin() {
+  return new Promise((resolve) => {
+    let data = "";
+    process.stdin.setEncoding("utf8");
+    process.stdin.on("data", (chunk) => (data += chunk));
+    process.stdin.on("end", () => resolve(data));
+  });
+}
+
+function checkFile(filePath) {
+  const warnings = [];
+
+  let content;
+  try {
+    content = fs.readFileSync(filePath, "utf8");
+  } catch {
+    return warnings;
+  }
+
+  const lines = content.split("\n");
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    const lineNum = i + 1;
+
+    for (const { pattern, label } of DEBUG_PATTERNS) {
+      if (pattern.test(line)) {
+        warnings.push(`${filePath}:${lineNum} -- possible ${label} leftover`);
+      }
+    }
+
+    if (TODO_PATTERN.test(line)) {
+      const match = line.match(TODO_PATTERN);
+      warnings.push(`${filePath}:${lineNum} -- ${match[1]} comment found`);
+    }
+  }
+
+  // Suggest linter based on file extension
+  const ext = path.extname(filePath).toLowerCase();
+  const linter = LINTER_SUGGESTIONS[ext];
+  if (linter) {
+    warnings.push(`Consider running ${linter} on ${path.basename(filePath)}`);
+  }
+
+  return warnings;
+}
+
+async function main() {
+  const raw = await readStdin();
+  let input;
+  try {
+    input = JSON.parse(raw);
+  } catch {
+    return;
+  }
+
+  const toolName = input.tool_name || "";
+  if (toolName !== "Write" && toolName !== "Edit") return;
+
+  const toolInput = input.tool_input || {};
+  const filePath = toolInput.file_path;
+  if (!filePath) return;
+
+  const warnings = checkFile(filePath);
+
+  if (warnings.length > 0) {
+    process.stderr.write(`[after-edit-lint] Warnings for ${path.basename(filePath)}:\n`);
+    for (const warning of warnings) {
+      process.stderr.write(`  ${warning}\n`);
+    }
+  }
+}
+
+main();

--- a/claude/hooks/secret-scanner.js
+++ b/claude/hooks/secret-scanner.js
@@ -1,0 +1,68 @@
+// PreToolUse hook: scans file content for leaked secrets before writes.
+// Blocks the tool call if a potential secret is detected.
+
+const SECRET_PATTERNS = [
+  { name: "AWS Access Key", pattern: /AKIA[0-9A-Z]{16}/ },
+  { name: "GitHub Personal Access Token", pattern: /ghp_[a-zA-Z0-9]{36}/ },
+  { name: "GitHub OAuth Token", pattern: /gho_[a-zA-Z0-9]{36}/ },
+  { name: "GitHub Server Token", pattern: /ghs_[a-zA-Z0-9]{36}/ },
+  { name: "GitHub Fine-Grained PAT", pattern: /github_pat_[a-zA-Z0-9_]{20,}/ },
+  { name: "Secret Key (sk-)", pattern: /sk-[a-zA-Z0-9]{20,}/ },
+  { name: "Stripe Live Key", pattern: /sk_live_[a-zA-Z0-9]{20,}/ },
+  { name: "Stripe Test Key", pattern: /sk_test_[a-zA-Z0-9]{20,}/ },
+  { name: "RSA Private Key", pattern: /-----BEGIN RSA PRIVATE KEY-----/ },
+  { name: "EC Private Key", pattern: /-----BEGIN EC PRIVATE KEY-----/ },
+  { name: "OpenSSH Private Key", pattern: /-----BEGIN OPENSSH PRIVATE KEY-----/ },
+  { name: "Generic Private Key", pattern: /-----BEGIN PRIVATE KEY-----/ },
+  {
+    name: "Hardcoded Secret Assignment",
+    pattern: /(?:secret|password|passwd|token|api_key|apikey|api_secret|access_token|auth_token|credentials)\s*[:=]\s*["'][a-zA-Z0-9+/=_\-]{16,}["']/i,
+  },
+];
+
+function readStdin() {
+  return new Promise((resolve) => {
+    let data = "";
+    process.stdin.setEncoding("utf8");
+    process.stdin.on("data", (chunk) => (data += chunk));
+    process.stdin.on("end", () => resolve(data));
+  });
+}
+
+function scanContent(content) {
+  const findings = [];
+  for (const { name, pattern } of SECRET_PATTERNS) {
+    if (pattern.test(content)) {
+      findings.push(name);
+    }
+  }
+  return findings;
+}
+
+async function main() {
+  const raw = await readStdin();
+  let input;
+  try {
+    input = JSON.parse(raw);
+  } catch {
+    return;
+  }
+
+  const toolInput = input.tool_input || {};
+  // Write tool uses "content", Edit tool uses "new_string"
+  const content = toolInput.content || toolInput.new_string || "";
+
+  if (!content) return;
+
+  const findings = scanContent(content);
+
+  if (findings.length > 0) {
+    const result = {
+      decision: "block",
+      reason: `Potential secret detected: ${findings.join(", ")}`,
+    };
+    process.stdout.write(JSON.stringify(result));
+  }
+}
+
+main();

--- a/claude/hooks/session-start.js
+++ b/claude/hooks/session-start.js
@@ -1,0 +1,130 @@
+// Notification hook: detects project environment at session start.
+// Outputs an informational summary to stderr -- does not block anything.
+
+const fs = require("fs");
+const path = require("path");
+const { execFileSync } = require("child_process");
+
+function readStdin() {
+  return new Promise((resolve) => {
+    let data = "";
+    process.stdin.setEncoding("utf8");
+    process.stdin.on("data", (chunk) => (data += chunk));
+    process.stdin.on("end", () => resolve(data));
+  });
+}
+
+function fileExists(filePath) {
+  try {
+    fs.accessSync(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function dirExists(dirPath) {
+  try {
+    return fs.statSync(dirPath).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+function getGitBranch() {
+  try {
+    return execFileSync("git", ["rev-parse", "--abbrev-ref", "HEAD"], {
+      encoding: "utf8",
+      stdio: ["pipe", "pipe", "pipe"],
+    }).trim();
+  } catch {
+    return null;
+  }
+}
+
+function detectEnvironment(cwd) {
+  const info = [];
+
+  // Language/runtime detection
+  const projectFiles = [
+    { file: "package.json", label: "Node.js (package.json)" },
+    { file: "requirements.txt", label: "Python (requirements.txt)" },
+    { file: "pyproject.toml", label: "Python (pyproject.toml)" },
+    { file: "Cargo.toml", label: "Rust (Cargo.toml)" },
+    { file: "go.mod", label: "Go (go.mod)" },
+  ];
+
+  for (const { file, label } of projectFiles) {
+    if (fileExists(path.join(cwd, file))) {
+      info.push(`Project type: ${label}`);
+    }
+  }
+
+  // Config files
+  const configs = [];
+  const configPatterns = [
+    { glob: ".eslintrc", label: "ESLint" },
+    { glob: "eslint.config", label: "ESLint" },
+    { glob: ".prettierrc", label: "Prettier" },
+    { glob: "prettier.config", label: "Prettier" },
+    { glob: "tsconfig.json", label: "TypeScript" },
+    { glob: ".editorconfig", label: "EditorConfig" },
+  ];
+
+  for (const { glob, label } of configPatterns) {
+    const extensions = ["", ".js", ".cjs", ".mjs", ".json", ".yml", ".yaml"];
+    for (const ext of extensions) {
+      if (fileExists(path.join(cwd, glob + ext))) {
+        if (!configs.includes(label)) configs.push(label);
+        break;
+      }
+    }
+  }
+
+  if (configs.length > 0) {
+    info.push(`Config: ${configs.join(", ")}`);
+  }
+
+  // .env.example reminder
+  if (fileExists(path.join(cwd, ".env.example"))) {
+    if (!fileExists(path.join(cwd, ".env"))) {
+      info.push("Note: .env.example found but no .env -- consider copying it");
+    }
+  }
+
+  // CI detection
+  const ciSystems = [];
+  if (dirExists(path.join(cwd, ".github", "workflows"))) {
+    ciSystems.push("GitHub Actions");
+  }
+  if (fileExists(path.join(cwd, ".gitlab-ci.yml"))) {
+    ciSystems.push("GitLab CI");
+  }
+  if (ciSystems.length > 0) {
+    info.push(`CI: ${ciSystems.join(", ")}`);
+  }
+
+  // Git branch
+  const branch = getGitBranch();
+  if (branch) {
+    info.push(`Git branch: ${branch}`);
+  }
+
+  return info;
+}
+
+async function main() {
+  await readStdin(); // consume stdin even though we don't need it
+
+  const cwd = process.cwd();
+  const info = detectEnvironment(cwd);
+
+  if (info.length > 0) {
+    process.stderr.write(`[session-start] Environment detected:\n`);
+    for (const line of info) {
+      process.stderr.write(`  ${line}\n`);
+    }
+  }
+}
+
+main();

--- a/claude/rules/coding-style.md
+++ b/claude/rules/coding-style.md
@@ -1,0 +1,35 @@
+# Coding Style
+
+Universal conventions for clean, maintainable code.
+
+## Naming
+
+- Use descriptive names that reveal intent -- avoid abbreviations
+- Follow language conventions for casing (camelCase, snake_case, PascalCase)
+- Booleans should read as predicates: `is_valid`, `hasAccess`, `shouldRetry`
+
+## Functions
+
+- Single responsibility -- each function does one thing well
+- Keep functions under ~50 lines; extract when complexity grows, not preemptively
+- Use early returns to reduce nesting and clarify control flow
+- Prefer pure functions where practical -- explicit inputs and outputs
+
+## Comments and Documentation
+
+- Write code that explains itself; add comments only where logic is non-obvious
+- Never commit commented-out code -- use version control instead
+- Document "why" not "what" -- the code already shows what it does
+
+## Structure
+
+- DRY, but avoid premature abstraction -- three similar lines are better than an unnecessary helper
+- Prefer composition over inheritance
+- Keep imports organized and remove unused ones
+- Avoid magic numbers and strings -- use named constants
+
+## Error Handling
+
+- Error messages should be actionable and include context (what failed, why, what to do)
+- Fail fast and loud -- silent failures are harder to debug than noisy ones
+- Handle errors at the appropriate level -- don't catch what you can't handle meaningfully

--- a/claude/rules/git-workflow.md
+++ b/claude/rules/git-workflow.md
@@ -1,0 +1,40 @@
+# Git Workflow
+
+Conventional commits and PR standards.
+
+## Commit Messages
+
+- Use Conventional Commits format: `type(scope): description`
+- Types: `feat`, `fix`, `docs`, `test`, `refactor`, `chore`, `ci`, `perf`
+- Write in imperative mood: "add feature" not "added feature"
+- Keep the subject line under 72 characters
+- Use the body to explain "why" when the diff alone is insufficient
+
+## Commit Hygiene
+
+- Atomic commits: one logical change per commit
+- Never commit secrets, credentials, or generated artifacts
+- Stage specific files -- avoid `git add .` which can include unintended files
+- Run tests before committing -- don't break the build
+
+## Branching
+
+- Branch naming: `type/short-description` (e.g., `feat/user-auth`, `fix/login-redirect`)
+- Keep branches short-lived -- merge within days, not weeks
+- Rebase feature branches on the base branch to keep history clean
+- Never force-push shared branches
+- Delete branches after merge
+
+## Pull Requests
+
+- PR titles follow Conventional Commit format
+- PRs should be reviewable in under 30 minutes -- split large changes
+- Always write a description explaining what changed and why
+- Link to relevant issues or context
+- Request reviews from people who own the affected code
+
+## Releases
+
+- Tag releases with semantic versioning: `vMAJOR.MINOR.PATCH`
+- Breaking changes bump the major version
+- Write changelogs from commit history -- good commits make this easy

--- a/claude/rules/performance.md
+++ b/claude/rules/performance.md
@@ -1,0 +1,36 @@
+# Performance
+
+Token optimization and context management for Claude Code.
+
+## Context Window
+
+- Keep `CLAUDE.md` concise -- every token counts against the context window
+- Use `.claude/rules/` for domain-specific rules instead of bloating `CLAUDE.md`
+- Archive completed work to memory files rather than keeping it in active context
+- Use `/clear` between unrelated tasks to reclaim context space
+
+## Task Delegation
+
+- Delegate research-heavy tasks to subagents to preserve the main context window
+- Use subagents for parallel, independent queries (e.g., searching multiple codebases)
+- Avoid duplicating work that a subagent is already handling
+
+## Efficient Tool Usage
+
+- Use `Glob` and `Grep` for targeted searches -- avoid broad directory exploration
+- Prefer focused file reads (specific line ranges) over reading entire files
+- Batch independent tool calls in parallel to minimize round-trips
+- Use dedicated tools (`Read`, `Edit`, `Write`) instead of shell equivalents
+
+## Task Management
+
+- Break large tasks into smaller, independently completable steps
+- Structure prompts with clear constraints to reduce wasted generation
+- Provide relevant context upfront rather than forcing iterative discovery
+- When a task is complete, state the result and stop -- avoid unnecessary elaboration
+
+## Code Generation
+
+- Generate minimal, correct code -- avoid boilerplate and over-abstraction
+- Prefer editing existing files over creating new ones to reduce file proliferation
+- Make focused, surgical changes rather than rewriting surrounding code

--- a/claude/rules/security.md
+++ b/claude/rules/security.md
@@ -1,0 +1,40 @@
+# Security
+
+Security-first defaults for every project.
+
+## Secrets Management
+
+- Never commit secrets, API keys, credentials, or `.env` files
+- Use environment variables or secret managers -- never hardcode credentials
+- Add sensitive file patterns to `.gitignore` before writing any code
+
+## Input Validation
+
+- Validate and sanitize all external inputs: user input, API responses, environment variables
+- Use allowlists over blocklists -- explicitly permit known-good values
+- Reject unexpected input types and shapes early at system boundaries
+
+## Injection Prevention
+
+- Use parameterized queries -- never string-concatenate SQL
+- Escape output to prevent XSS -- use framework-provided escaping by default
+- Avoid dynamic code execution and shell interpolation of user input
+
+## Authentication and Authorization
+
+- Principle of least privilege for all permissions, scopes, and tokens
+- Use constant-time comparison for secrets and tokens
+- Set secure defaults for cookies: `HttpOnly`, `Secure`, `SameSite`
+- Validate authentication on every request -- never trust client-side checks alone
+
+## Dependencies
+
+- Pin dependency versions to avoid supply chain attacks
+- Audit dependencies for known vulnerabilities regularly
+- Minimize the dependency surface -- fewer deps means fewer attack vectors
+
+## Logging and Monitoring
+
+- Log security-relevant events: auth failures, permission denials, input validation rejections
+- Never log sensitive data: passwords, tokens, PII, credentials
+- Include enough context in logs to reconstruct what happened without exposing secrets

--- a/claude/rules/testing.md
+++ b/claude/rules/testing.md
@@ -1,0 +1,41 @@
+# Testing
+
+TDD patterns and coverage standards.
+
+## Philosophy
+
+- Write tests before or alongside implementation, not after
+- Test behavior, not implementation details -- tests should survive refactors
+- Each test should answer: "what should happen when X?"
+
+## Test Structure
+
+- Follow Arrange-Act-Assert (or Given-When-Then)
+- One assertion per test where practical -- multiple assertions are fine if testing one logical behavior
+- Name tests descriptively: `test_<what>_<when>_<expected>`
+- Keep tests independent -- no shared mutable state between tests
+
+## Coverage Targets
+
+- Target 80%+ code coverage overall
+- 100% coverage for critical paths: auth, payments, data mutations
+- Coverage is a floor, not a ceiling -- don't write meaningless tests to hit a number
+
+## What to Test
+
+- Happy path and expected error conditions
+- Edge cases: empty inputs, boundary values, null/undefined, large inputs
+- Integration tests for API endpoints and database operations
+- Contract tests for external service interfaces
+
+## Mocking
+
+- Mock external dependencies (APIs, databases, file systems), not internal logic
+- Prefer fakes and stubs over complex mock frameworks when possible
+- Verify that mocks match the real interface -- outdated mocks hide bugs
+
+## Organization
+
+- Keep test files colocated with source or in a parallel test directory -- be consistent
+- Share test fixtures through explicit helpers, not implicit inheritance
+- Tests are production code -- apply the same quality standards

--- a/claude/skills/api-design.md
+++ b/claude/skills/api-design.md
@@ -1,0 +1,107 @@
+# API Design
+
+Design a RESTful API for a given resource, following consistent patterns and best practices.
+
+## Usage
+
+Invoke with `/api-design <resource or entity>` where the argument is the resource to design endpoints for (e.g., "users", "orders", "blog posts").
+
+## Workflow
+
+When this skill is invoked, follow these steps to produce a complete API design.
+
+### 1. Parse the Resource
+
+- Read `$ARGUMENTS` to identify the resource/entity
+- Determine relationships to other resources if mentioned (e.g., "user orders" implies nesting)
+- Identify the key fields and their types based on context
+
+### 2. Design Endpoints
+
+Follow these conventions strictly:
+
+**Resource Naming**
+- Use plural nouns: `/users`, `/orders`, `/products`
+- Nest for direct relationships: `/users/:id/orders`
+- Use kebab-case for multi-word resources: `/order-items`
+- Prefix all routes: `/api/v1/...`
+
+**Standard CRUD Endpoints**
+
+| Method | Path | Description | Status |
+|--------|------|-------------|--------|
+| GET | `/api/v1/{resources}` | List all (paginated) | 200 |
+| GET | `/api/v1/{resources}/:id` | Get single by ID | 200 / 404 |
+| POST | `/api/v1/{resources}` | Create new | 201 |
+| PUT | `/api/v1/{resources}/:id` | Full replace | 200 / 404 |
+| PATCH | `/api/v1/{resources}/:id` | Partial update | 200 / 404 |
+| DELETE | `/api/v1/{resources}/:id` | Delete | 204 / 404 |
+
+**Response Envelope**
+
+Success (single):
+```json
+{
+  "data": { "id": "...", "type": "resource", ... }
+}
+```
+
+Success (list):
+```json
+{
+  "data": [ ... ],
+  "meta": {
+    "page": { "cursor": "abc123", "limit": 20, "has_more": true },
+    "total": 142
+  }
+}
+```
+
+Error:
+```json
+{
+  "error": {
+    "code": "VALIDATION_ERROR",
+    "message": "Human-readable description",
+    "details": [
+      { "field": "email", "message": "must be a valid email address" }
+    ]
+  }
+}
+```
+
+**Pagination, Filtering, Sorting**
+- Cursor-based pagination: `?cursor=abc&limit=20`
+- Filtering by field: `?status=active&created_after=2024-01-01`
+- Sorting: `?sort=created_at&order=desc`
+- Default limit: 20, max limit: 100
+
+**Status Codes**
+- 200: Success
+- 201: Created (include `Location` header)
+- 204: Deleted (no body)
+- 400: Bad request / malformed input
+- 401: Unauthenticated
+- 403: Forbidden / insufficient permissions
+- 404: Resource not found
+- 409: Conflict (duplicate, state conflict)
+- 422: Unprocessable entity (validation failure)
+- 500: Internal server error
+
+### 3. Output
+
+Produce these deliverables:
+
+1. **Endpoint Table**: All endpoints with method, path, description, request body, and response status
+2. **Request/Response Examples**: Show a concrete curl or HTTP example for each endpoint with sample JSON bodies
+3. **OpenAPI Schema Snippet**: A YAML snippet defining the resource schema, compatible with OpenAPI 3.0, including:
+   - The resource schema under `components.schemas`
+   - Path definitions for at least the list and create endpoints
+   - Request body and response schemas
+
+### 4. Design Notes
+
+End with brief notes on:
+- **Auth**: Which endpoints require authentication and what scopes/roles
+- **Rate limiting**: Suggested limits (e.g., 100 req/min for list, 30 req/min for create)
+- **Caching**: Which GET endpoints are cacheable and suggested TTL

--- a/claude/skills/security-review.md
+++ b/claude/skills/security-review.md
@@ -1,0 +1,56 @@
+# Security Review
+
+Run a systematic security audit against a codebase target.
+
+## Usage
+
+Invoke with `/security-review [target]` where target is a file, directory, or module to audit. If no target is provided, review recently changed files (via `git diff` or `git log`).
+
+## Workflow
+
+When this skill is invoked, follow these steps exactly:
+
+### 1. Identify the Target
+
+- If `$ARGUMENTS` is provided, use it as the audit target (file path, directory, or glob pattern)
+- If no arguments, run `git diff --name-only HEAD~5` to find recently changed files and audit those
+
+### 2. Run the Security Checklist
+
+For each file in scope, systematically check every item below. Do not skip items -- explicitly mark each as PASS, FAIL, or N/A.
+
+- **Input Validation**: All user inputs are validated and sanitized. Check request bodies, query params, URL params, headers, file uploads.
+- **Authentication**: Auth flows are correct. Tokens have expiry, are validated server-side, and use secure storage. Sessions are invalidated on logout.
+- **Authorization**: Access controls enforce least privilege. Role-based permissions are checked on every protected endpoint. No IDOR vulnerabilities.
+- **Data Protection**: Sensitive data (PII, passwords, tokens) is encrypted at rest and in transit. No sensitive data in URLs or query strings.
+- **SQL Injection**: All database queries use parameterized queries or prepared statements. No string concatenation in SQL.
+- **XSS**: All output is encoded/escaped for the appropriate context (HTML, JS, URL, CSS). No unsafe innerHTML usage without prior sanitization via a library like DOMPurify.
+- **CSRF**: State-changing operations require anti-CSRF tokens. SameSite cookie attributes are set.
+- **Secrets**: No hardcoded credentials, API keys, connection strings, or private keys in source. Check for `.env` files committed to git.
+- **Dependencies**: Run dependency audit (`npm audit`, `pip audit`, `cargo audit`, etc.) and flag known vulnerabilities.
+- **Logging**: No sensitive data (passwords, tokens, PII) written to logs. Errors do not leak stack traces or internal details to clients.
+
+### 3. Report Findings
+
+Output findings grouped by severity:
+
+**CRITICAL** -- Must fix before deploy. Active exploitability.
+- Format: `[CRITICAL] file_path:line_number -- Description of the vulnerability. Suggested fix: ...`
+
+**WARNING** -- Should fix soon. Potential risk under certain conditions.
+- Format: `[WARNING] file_path:line_number -- Description of the issue. Suggested fix: ...`
+
+**INFO** -- Best practice recommendations. Not immediately exploitable.
+- Format: `[INFO] file_path:line_number -- Description. Recommendation: ...`
+
+### 4. Summary
+
+End with a summary table:
+
+| Severity | Count |
+|----------|-------|
+| CRITICAL | N     |
+| WARNING  | N     |
+| INFO     | N     |
+
+If zero findings across all categories, state: "No security issues found in the audited scope."

--- a/claude/skills/tdd-workflow.md
+++ b/claude/skills/tdd-workflow.md
@@ -1,0 +1,55 @@
+# TDD Workflow
+
+Implement a feature using strict Test-Driven Development (Red-Green-Refactor).
+
+## Usage
+
+Invoke with `/tdd-workflow <feature description>` where the argument describes the function, module, or behavior to implement.
+
+## Workflow
+
+When this skill is invoked, follow the Red-Green-Refactor cycle exactly as described below. Do not skip steps or combine phases.
+
+### 0. Parse the Requirement
+
+- Read `$ARGUMENTS` to understand what needs to be implemented
+- Identify the project's existing test framework, conventions, and file structure before writing anything
+- Determine where the implementation and test files should live based on existing patterns
+
+### 1. Red -- Write Failing Tests First
+
+Before writing any implementation code:
+
+1. Identify test cases covering:
+   - **Happy path**: The primary expected behavior
+   - **Edge cases**: Empty inputs, boundary values, large inputs, null/undefined
+   - **Error conditions**: Invalid inputs, missing required fields, permission failures
+2. Write the test file using the project's existing test framework and naming conventions
+3. Run the tests and confirm they **fail** (red). Paste the test runner output showing failures.
+4. If tests pass without implementation, the tests are not testing the right thing -- rewrite them.
+
+### 2. Green -- Minimal Implementation
+
+1. Write the **minimum code** necessary to make all tests pass
+2. Do not optimize, do not add abstractions, do not handle cases not covered by tests
+3. Run the tests and confirm they **all pass** (green). Paste the test runner output.
+4. If any test fails, fix the implementation (not the test) until green.
+
+### 3. Refactor -- Improve Without Changing Behavior
+
+1. Review the implementation for:
+   - Code duplication (DRY)
+   - Unclear naming
+   - Functions doing too much (extract helpers only if clearly warranted)
+   - Performance issues obvious at a glance
+2. Make improvements while keeping all tests passing
+3. Run the tests again and confirm they **still pass**. Paste the output.
+
+### 4. Summary
+
+Report what was done:
+
+- **Files created/modified**: List each file with its absolute path
+- **Tests**: Number of test cases, all passing
+- **Implementation**: Brief description of the approach taken
+- **Refactoring**: What was improved in the refactor step (or "None needed")


### PR DESCRIPTION
## Summary

Adds a `claude/` folder with curated, framework-agnostic starter configs for Claude Code, extracted and adapted from [everything-claude-code](https://github.com/affaan-m/everything-claude-code).

**15 new files (1,086 lines):**

- `claude/README.md` — Index with usage instructions and credits
- `claude/CLAUDE.md` — Project memory template with placeholder sections
- `claude/AGENTS.md` — Agent orchestration guide with 4 universal agent definitions
- `claude/rules/` — 5 drop-in rulesets (coding-style, security, testing, git-workflow, performance)
- `claude/hooks/` — README + 3 JS hooks (secret-scanner, session-start, after-edit-lint)
- `claude/skills/` — 3 slash-command skills (security-review, tdd-workflow, api-design)
- Root `README.md` updated with link in "Agent Configs and Dotfiles" section

**What's excluded (by design):**
Framework-specific rules (Django, Spring Boot, Swift, Go), plugin packaging, MCP configs, business skills, and the full 13-agent setup — only universally applicable content.

## Test plan

- [x] All 3 JS hook files pass `node -c` syntax check
- [x] Content is framework-agnostic (no Django/Spring/Swift references)
- [x] Root README link points to `claude/` correctly
- [ ] Manual review of content quality and accuracy