### PR TITLE
curation: add audit-driven resources + governance templates

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,10 @@
+# Default owners for all files
+* @0xNyk
+
+# CI and repo policy
+/.github/ @0xNyk
+
+# Core curation surfaces
+/README.md @0xNyk
+/guides/ @0xNyk
+/hermes/ @0xNyk

--- a/.github/ISSUE_TEMPLATE/add-resource.yml
+++ b/.github/ISSUE_TEMPLATE/add-resource.yml
@@ -1,0 +1,83 @@
+name: Add resource
+description: Propose a new resource for the awesome list.
+title: "[Add]: "
+labels:
+  - curation
+body:
+  - type: input
+    id: name
+    attributes:
+      label: Resource name
+      placeholder: Example Tool
+    validations:
+      required: true
+
+  - type: input
+    id: url
+    attributes:
+      label: Resource URL
+      placeholder: https://github.com/org/repo
+    validations:
+      required: true
+
+  - type: dropdown
+    id: section
+    attributes:
+      label: Target section
+      options:
+        - Agent Frameworks
+        - Coding Agents
+        - Voice and Multimodal Agents
+        - Hermes Stack
+        - CLI and TUI Tools
+        - Agent Runtime Infrastructure
+        - MCP Ecosystem
+        - Prompt Engineering
+        - Agent Harnessing and Evaluation
+        - Context Engineering
+        - Neural Networks and Neural Linking
+        - Obsidian Vault Architecture for Agents
+        - Agent Security and Robustness
+        - Agent Configs and Dotfiles
+        - Skill Engineering and Playbooks
+        - Knowledge Graphs and Memory
+        - Solana Agent Infrastructure
+        - Agent Identity and Wallets
+        - Agent Payments
+        - DeFi Agents
+        - Quant and Trading Agents
+        - Agent Observability and Testing
+        - Research Papers
+        - Communities
+    validations:
+      required: true
+
+  - type: textarea
+    id: rationale
+    attributes:
+      label: Why this belongs
+      description: Explain unique value and fit for the selected section.
+      placeholder: What does it add that we do not already have?
+    validations:
+      required: true
+
+  - type: textarea
+    id: score
+    attributes:
+      label: Awesome Score (1-5 each)
+      description: Maintenance, Docs, Production readiness, Unique value, Security posture.
+      placeholder: Maintenance 4, Docs 4, Production 3, Unique 4, Security 3
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Checklist
+      options:
+        - label: I verified the link is accessible.
+          required: true
+        - label: I checked the project is actively maintained.
+          required: true
+        - label: I checked this is not a duplicate entry unless intentional cross-listing.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Questions / Discussion
+    url: https://github.com/0xNyk/awesome-agent-cortex/discussions
+    about: Ask broader questions or propose larger direction changes in Discussions.

--- a/.github/ISSUE_TEMPLATE/link-report.yml
+++ b/.github/ISSUE_TEMPLATE/link-report.yml
@@ -1,0 +1,46 @@
+name: Broken or stale link
+description: Report a broken link or stale repository in the list.
+title: "[Link]: "
+labels:
+  - links
+  - maintenance
+body:
+  - type: input
+    id: location
+    attributes:
+      label: Location in repo
+      description: File and, if possible, line/section where the link appears.
+      placeholder: README.md - MCP Ecosystem
+    validations:
+      required: true
+
+  - type: input
+    id: broken_url
+    attributes:
+      label: Broken URL
+      placeholder: https://example.com
+    validations:
+      required: true
+
+  - type: textarea
+    id: evidence
+    attributes:
+      label: What happened
+      description: Error code, redirect loop, archived repo, etc.
+      placeholder: HTTP 404, repo archived, domain expired, etc.
+    validations:
+      required: true
+
+  - type: input
+    id: replacement
+    attributes:
+      label: Suggested replacement URL (optional)
+      placeholder: https://github.com/org/new-repo
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Checklist
+      options:
+        - label: I confirmed this issue is not already reported.
+          required: true

--- a/.github/ISSUE_TEMPLATE/new-section.yml
+++ b/.github/ISSUE_TEMPLATE/new-section.yml
@@ -1,0 +1,42 @@
+name: Propose new section
+description: Suggest a new top-level section for the awesome list.
+title: "[Section]: "
+labels:
+  - curation
+body:
+  - type: input
+    id: section_name
+    attributes:
+      label: Proposed section name
+      placeholder: Agent Governance and Policy
+    validations:
+      required: true
+
+  - type: textarea
+    id: rationale
+    attributes:
+      label: Why this section is needed
+      description: Explain the gap in current taxonomy.
+    validations:
+      required: true
+
+  - type: textarea
+    id: seed_entries
+    attributes:
+      label: Seed entries (minimum 5)
+      description: List at least 5 candidate resources with links.
+      placeholder: |
+        - [Example 1](https://...)
+        - [Example 2](https://...)
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Checklist
+      options:
+        - label: I confirmed there are at least 5 qualifying entries.
+          required: true
+        - label: I checked this does not fit better under existing sections.
+          required: true

--- a/.github/scripts/check_alpha_sections.py
+++ b/.github/scripts/check_alpha_sections.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+import re
+import sys
+from pathlib import Path
+
+TARGET_SECTIONS = {
+    'Agent Frameworks',
+    'Voice and Multimodal Agents',
+    'Agent Runtime Infrastructure',
+    'MCP Ecosystem',
+    'Agent Security and Robustness',
+    'Agent Configs and Dotfiles',
+    'Skill Engineering and Playbooks',
+    'Knowledge Graphs and Memory',
+    'Agent Identity and Wallets',
+    'Agent Payments',
+    'DeFi Agents',
+    'Quant and Trading Agents',
+    'Agent Observability and Testing',
+    'Research Papers',
+    'Communities',
+}
+
+
+def parse_sections(lines):
+    sections = {}
+    section = None
+    items = []
+    for line in lines:
+        m = re.match(r'^##\s+(.+)$', line)
+        if m:
+            if section is not None:
+                sections[section] = items
+            section = m.group(1).strip()
+            items = []
+            continue
+        m = re.match(r'^- \[([^\]]+)\]\(', line)
+        if m and section is not None:
+            items.append(m.group(1).strip())
+    if section is not None:
+        sections[section] = items
+    return sections
+
+
+def main():
+    path = Path(sys.argv[1] if len(sys.argv) > 1 else 'README.md')
+    lines = path.read_text(encoding='utf-8').splitlines()
+    sections = parse_sections(lines)
+
+    violations = []
+    for name in sorted(TARGET_SECTIONS):
+        items = sections.get(name, [])
+        normalized = [i.casefold() for i in items]
+        if normalized != sorted(normalized):
+            for i in range(len(items) - 1):
+                if normalized[i] > normalized[i + 1]:
+                    violations.append((name, items[i], items[i + 1]))
+                    break
+
+    if violations:
+        print('Alphabetical order violations detected in curated sections:\n')
+        for section, a, b in violations:
+            print(f'- {section}: "{a}" should come after "{b}"')
+        sys.exit(1)
+
+    print('Alphabetical order OK in curated sections.')
+
+
+if __name__ == '__main__':
+    main()

--- a/.github/workflows/awesome-lint.yml
+++ b/.github/workflows/awesome-lint.yml
@@ -1,0 +1,33 @@
+name: Awesome Lint
+
+on:
+  pull_request:
+    paths:
+      - 'README.md'
+      - '.github/workflows/awesome-lint.yml'
+      - '.github/scripts/check_alpha_sections.py'
+  push:
+    branches: [main]
+    paths:
+      - 'README.md'
+      - '.github/workflows/awesome-lint.yml'
+      - '.github/scripts/check_alpha_sections.py'
+
+jobs:
+  awesome-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Run awesome-lint (advisory baseline)
+        continue-on-error: true
+        run: npx --yes awesome-lint README.md
+
+      - name: Check alphabetical order in curated sections
+        run: python3 .github/scripts/check_alpha_sections.py README.md

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Multi-agent orchestration, single-agent SDKs, and runtime frameworks.
 - [LlamaIndex](https://github.com/run-llama/llama_index) - Data framework for document agents, retrieval, and workflow orchestration.
 - [Magentic-One](https://github.com/microsoft/autogen/tree/main/python/packages/autogen-magentic-one) - Multi-agent team for complex web and file tasks.
 - [Mastra](https://github.com/mastra-ai/mastra) - TypeScript framework for building AI applications and agents.
+- [Microsoft Agent Framework](https://github.com/microsoft/agent-framework) - Framework for building, orchestrating, and deploying agents with Python and .NET support.
 - [OpenAI Agents SDK](https://github.com/openai/openai-agents-python) - Official SDK for building agents with OpenAI models.
 - [OpenClaw](https://github.com/openclaw/openclaw) - Self-hosted personal AI agent with multi-platform messaging and skill registry.
 - [Phidata](https://github.com/phidatahq/phidata) - Toolkit for building AI assistants with memory and tools.
@@ -152,6 +153,7 @@ Terminal-based agent interfaces and developer tools.
 
 Execution sandboxes and runtime platforms for safely running agent actions and generated code.
 
+- [CUA](https://github.com/trycua/cua) - Open-source infrastructure for computer-use agents with sandboxes, SDKs, and benchmarks.
 - [Daytona](https://github.com/daytonaio/daytona) - Secure and elastic runtime infrastructure for AI-generated code execution.
 - [E2B](https://github.com/e2b-dev/E2B) - Open-source secure cloud sandbox environment for AI agents.
 - [Firecracker](https://github.com/firecracker-microvm/firecracker) - Secure and fast microVM technology for isolated agent execution.
@@ -165,9 +167,12 @@ Execution sandboxes and runtime platforms for safely running agent actions and g
 Model Context Protocol servers, clients, and tooling.
 
 - [Awesome MCP Servers](https://github.com/punkpeye/awesome-mcp-servers) - Curated list of MCP server implementations.
+- [Chrome DevTools MCP](https://github.com/ChromeDevTools/chrome-devtools-mcp) - Official Chrome DevTools MCP server for coding and browser automation agents.
 - [FastMCP](https://github.com/PrefectHQ/fastmcp) - Pythonic framework for building MCP servers and clients quickly.
+- [GitHub MCP Server](https://github.com/github/github-mcp-server) - Official MCP server for GitHub workflows and repository actions.
 - [mcp](https://github.com/modelcontextprotocol/servers) - Official reference MCP server implementations.
 - [MCP Agent](https://github.com/lastmile-ai/mcp-agent) - Framework patterns for building agents on top of MCP.
+- [MCP for Beginners](https://github.com/microsoft/mcp-for-beginners) - Cross-language curriculum and practical examples for learning MCP.
 - [MCP Go SDK](https://github.com/mark3labs/mcp-go) - Go implementation of the Model Context Protocol.
 - [MCP Inspector](https://github.com/modelcontextprotocol/inspector) - Official inspector and debugging tool for MCP servers.
 - [MCP Python SDK](https://github.com/modelcontextprotocol/python-sdk) - Official Python SDK for building MCP servers.
@@ -205,6 +210,7 @@ Harnesses, benchmarks, and evaluation frameworks for measuring agent quality and
 - [browser-use](https://github.com/browser-use/browser-use) - Framework for browser task automation and agent web interaction loops.
 - [Inspect AI](https://github.com/UKGovernmentBEIS/inspect_ai) - Open-source framework for reproducible LLM and agent evaluations.
 - [JailbreakBench](https://github.com/JailbreakBench/jailbreakbench) - Open robustness benchmark for measuring jailbreak resistance in language models and agents.
+- [MCPMark](https://github.com/eval-sys/mcpmark) - Stress-testing benchmark for evaluating model and agent capability on MCP tasks.
 - [MLE-bench](https://github.com/openai/mle-bench) - Benchmark harness for autonomous ML engineering tasks.
 - [OSWorld](https://github.com/xlang-ai/OSWorld) - Open-ended benchmark environment for desktop computer-use agents.
 - [OpenCUA](https://github.com/xlang-ai/OpenCUA) - Open foundation stack for building and evaluating computer-use agents.
@@ -226,6 +232,7 @@ Harnesses, benchmarks, and evaluation frameworks for measuring agent quality and
 Systems-level context design: memory, retrieval, compression, routing, and long-horizon state management.
 Focus here on *what information the model gets, when, and in what form*.
 
+- [12-Factor Agents](https://github.com/humanlayer/12-factor-agents) - Engineering principles for building reliable, production-grade LLM agents.
 - [Anthropic: Building Effective Agents](https://www.anthropic.com/engineering/building-effective-agents) - Practical engineering patterns for agent design and execution loops.
 - [Anthropic: Contextual Retrieval](https://www.anthropic.com/engineering/contextual-retrieval) - Retrieval architecture guidance for improving grounding and precision.
 - [Anthropic: Effective Context Engineering for AI Agents](https://www.anthropic.com/engineering/effective-context-engineering-for-ai-agents) - Production guidance for context composition and lifecycle management.
@@ -281,6 +288,7 @@ Safety, red-teaming, and robustness tools for hardening agent behavior.
 - [Invariant](https://github.com/invariantlabs-ai/invariant) - Guardrails framework for secure and robust agent development.
 - [JailbreakBench](https://github.com/JailbreakBench/jailbreakbench) - Open robustness benchmark for measuring jailbreak resistance in language models and agents.
 - [llm-attacks](https://github.com/llm-attacks/llm-attacks) - Reference implementation and resources for adversarial jailbreak attack evaluation.
+- [MCP Security Best Practices](https://modelcontextprotocol.io/docs/tutorials/security/security_best_practices) - Official security guidance for MCP authorization flows, threats, and mitigations.
 - [NeMo Guardrails](https://github.com/NVIDIA-NeMo/Guardrails) - Toolkit for adding programmable safety and policy guardrails to LLM systems.
 - [Promptfoo](https://github.com/promptfoo/promptfoo) - Red-teaming and robustness testing toolkit for LLM systems.
 - [PyRIT](https://github.com/Azure/PyRIT) - Python Risk Identification Tool for proactively testing generative AI security risks.
@@ -437,6 +445,7 @@ Debugging, tracing, evaluation, and testing tools for AI agents.
 - [LiteLLM](https://github.com/BerriAI/litellm) - LLM gateway and proxy with logging, cost tracking, and routing controls.
 - [OpenAI Evals](https://github.com/openai/evals) - Framework and benchmark registry for evaluating LLM systems.
 - [OpenLLMetry](https://github.com/traceloop/openllmetry) - OpenTelemetry-based observability for LLM applications.
+- [Opik](https://github.com/comet-ml/opik) - Open-source platform for LLM and agent tracing, evaluation, and monitoring.
 - [Phoenix](https://github.com/Arize-ai/phoenix) - Open-source AI observability platform from Arize.
 - [Portkey](https://github.com/Portkey-AI/gateway) - AI gateway with observability, caching, and fallback routing.
 - [SigNoz](https://github.com/SigNoz/signoz) - OpenTelemetry-native observability platform for traces, logs, and metrics.


### PR DESCRIPTION
## Summary
- add audit-backed, high-signal resources to README (frameworks, MCP, eval, observability, context/security)
- add  forms for resource proposals, broken links, and new section requests
- add  to tighten review routing
- add  workflow (advisory baseline) plus enforced curated-section alphabetical check

## Validation
- OK: checked 53 markdown files, no broken internal links.
- Alphabetical order OK in curated sections.

## Notes
-  currently runs in advisory mode to surface baseline violations while avoiding disruption; alphabetical order in curated sections is enforced as a hard gate.
