### PR TITLE
docs(research): deepen arXiv map with must-reads, watchlist, and refresh workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ Harnesses, benchmarks, and evaluation frameworks for measuring agent quality and
 
 Deep-dive reading map organized by the major categories in this repository.
 
-- [ArXiv Deep Research Map (this repo)](guides/arxiv-deep-research-map.md) - Curated paper paths across agent frameworks, coding agents, MCP/tool use, eval reliability, context/memory, security, multimodal, quant, and on-chain/DeFi-adjacent research.
+- [ArXiv Deep Research Map (this repo)](guides/arxiv-deep-research-map.md) - Curated paper paths with per-category must-reads, a recent watchlist, and a monthly refresh workflow across frameworks, coding, MCP/tool use, eval reliability, memory, security, multimodal, quant, and on-chain/DeFi-adjacent research.
 
 ## Context Engineering
 

--- a/README.md
+++ b/README.md
@@ -472,8 +472,8 @@ Debugging, tracing, evaluation, and testing tools for AI agents.
 
 Curated papers on AI agents, multi-agent systems, and agent infrastructure.
 
-- [ArXiv Deep Research Map (this repo)](guides/arxiv-deep-research-map.md) - Category-by-category reading map spanning frameworks, coding, MCP/tool use, memory, security, multimodal, and quant/on-chain adjacent domains.
 - [A Survey on Large Language Model based Autonomous Agents](https://arxiv.org/abs/2308.11432) - Comprehensive survey of LLM-based agent architectures.
+- [ArXiv Deep Research Map (this repo)](guides/arxiv-deep-research-map.md) - Category-by-category reading map spanning frameworks, coding, MCP/tool use, memory, security, multimodal, and quant/on-chain adjacent domains.
 - [Awesome AI Agent Papers](https://github.com/VoltAgent/awesome-ai-agent-papers) - Continuously updated collection of agent research papers.
 - [Chain-of-Thought Prompting](https://arxiv.org/abs/2201.11903) - Foundational paper on reasoning in language models.
 - [Generative Agents](https://arxiv.org/abs/2304.03442) - Simulating human behavior with LLM-driven agents in a sandbox.

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ CLI usage).
 - [MCP Ecosystem](#mcp-ecosystem)
 - [Prompt Engineering](#prompt-engineering)
 - [Agent Harnessing and Evaluation](#agent-harnessing-and-evaluation)
+- [ArXiv Deep Research Map](#arxiv-deep-research-map)
 - [Context Engineering](#context-engineering)
 - [Neural Networks and Neural Linking](#neural-networks-and-neural-linking)
 - [Obsidian Vault Architecture for Agents](#obsidian-vault-architecture-for-agents)
@@ -203,6 +204,15 @@ Focus here on *what to ask and how to phrase it* at the prompt layer.
 
 Harnesses, benchmarks, and evaluation frameworks for measuring agent quality and reliability.
 
+### Benchmark Reality Check (real-world tool use)
+
+- [MCPMark (paper)](https://arxiv.org/abs/2509.24002) - 127-task MCP benchmark; reports best pass@1 at 52.56% (gpt-5-medium), with several strong models below 30% pass@1.
+- [MCPMark (leaderboard)](https://mcpmark.ai/) - Live model comparisons for realistic MCP task execution.
+- [τ-bench](https://arxiv.org/abs/2406.12045) - Tool-agent-user benchmark; reports strong function-calling agents still below 50% task success in its setup.
+- [OSWorld](https://arxiv.org/abs/2404.07972) - Open-ended computer-use benchmark; reports best model 12.24% vs 72.36% human success in initial results.
+- [WebArena](https://arxiv.org/abs/2307.13854) - Realistic web-task benchmark; reports best GPT-4-based agent at 14.41% vs 78.24% human.
+- [GAIA](https://arxiv.org/abs/2311.12983) - General assistant benchmark; original framing reports large human-model gap on tool-heavy questions.
+
 - [AgentBench](https://github.com/THUDM/AgentBench) - Multi-domain benchmark suite for evaluating LLMs as agents.
 - [AgentEvals](https://github.com/langchain-ai/agentevals) - Evaluation utilities for scoring agent trajectories and outcomes.
 - [AutoGen agbench](https://github.com/microsoft/autogen/blob/main/python/packages/agbench/README.md) - Benchmark runner for AutoGen agent workflows.
@@ -226,6 +236,12 @@ Harnesses, benchmarks, and evaluation frameworks for measuring agent quality and
 - [HELM](https://crfm.stanford.edu/helm/latest/) - Standardized evaluation framework for model and agent behavior comparison.
 - [GAIA Benchmark](https://huggingface.co/gaia-benchmark) - Realistic benchmark for tool-using, multi-step general assistant tasks.
 - [Agent Harnessing Playbook (this repo)](guides/agent-harnessing-playbook.md) - Practical framework for benchmark design, regression gates, and release readiness.
+
+## ArXiv Deep Research Map
+
+Deep-dive reading map organized by the major categories in this repository.
+
+- [ArXiv Deep Research Map (this repo)](guides/arxiv-deep-research-map.md) - Curated paper paths across agent frameworks, coding agents, MCP/tool use, eval reliability, context/memory, security, multimodal, quant, and on-chain/DeFi-adjacent research.
 
 ## Context Engineering
 
@@ -456,6 +472,7 @@ Debugging, tracing, evaluation, and testing tools for AI agents.
 
 Curated papers on AI agents, multi-agent systems, and agent infrastructure.
 
+- [ArXiv Deep Research Map (this repo)](guides/arxiv-deep-research-map.md) - Category-by-category reading map spanning frameworks, coding, MCP/tool use, memory, security, multimodal, and quant/on-chain adjacent domains.
 - [A Survey on Large Language Model based Autonomous Agents](https://arxiv.org/abs/2308.11432) - Comprehensive survey of LLM-based agent architectures.
 - [Awesome AI Agent Papers](https://github.com/VoltAgent/awesome-ai-agent-papers) - Continuously updated collection of agent research papers.
 - [Chain-of-Thought Prompting](https://arxiv.org/abs/2201.11903) - Foundational paper on reasoning in language models.

--- a/guides/arxiv-deep-research-map.md
+++ b/guides/arxiv-deep-research-map.md
@@ -1,118 +1,172 @@
 # ArXiv Deep Research Map for Agent Cortex
 
-Purpose: a high-signal arXiv reading map that deepens coverage across the major categories in this repo.
+Purpose: deepen this repo with a practical, operator-first arXiv map across all major categories.
 
-How to use this:
-- Start with "Core" papers in each category.
-- Use "Expansion" papers when designing or benchmarking production systems.
-- Treat benchmark scores as moving targets; always check live leaderboards and method cards.
+How to use this map:
+- Start with the "Top 3 must-read" papers in each category.
+- Use "Expansion" to go deeper once you have a baseline.
+- Re-check benchmark claims against current leaderboards before publishing hard numbers.
 
 ## 1) Agent Frameworks and Reasoning Loops
 
-Core:
-- [ReAct (2022)](https://arxiv.org/abs/2210.03629) - Reasoning + acting loop for tool-using agents.
-- [Reflexion (2023)](https://arxiv.org/abs/2303.11366) - Verbal self-feedback for iterative improvement.
-- [Toolformer (2023)](https://arxiv.org/abs/2302.04761) - Self-supervised tool-use behavior induction.
+Top 3 must-read (and why):
+- [ReAct (2022)](https://arxiv.org/abs/2210.03629) - Canonical think+act loop for tool-using agents.
+- [Reflexion (2023)](https://arxiv.org/abs/2303.11366) - Strong pattern for self-critique and iterative improvement.
+- [Toolformer (2023)](https://arxiv.org/abs/2302.04761) - Foundation for model-native tool-use behavior.
 
 Expansion:
-- [Generative Agents (2023)](https://arxiv.org/abs/2304.03442) - Memory/planning/reflection architecture in sandbox worlds.
-- [A Survey on LLM-based Autonomous Agents (2023)](https://arxiv.org/abs/2308.11432) - Broad architecture landscape.
+- [Generative Agents (2023)](https://arxiv.org/abs/2304.03442)
+- [A Survey on LLM-based Autonomous Agents (2023)](https://arxiv.org/abs/2308.11432)
 
 ## 2) Coding Agents
 
-Core:
-- [SWE-bench (2023)](https://arxiv.org/abs/2310.06770) - Real GitHub issue resolution benchmark.
-- [SWE-bench Multimodal (2024)](https://arxiv.org/abs/2410.03859) - Visual software understanding extension.
-- [SWE-bench Goes Live! (2025)](https://arxiv.org/abs/2505.23419) - Live benchmark methodology and updates.
+Top 3 must-read (and why):
+- [SWE-bench (2023)](https://arxiv.org/abs/2310.06770) - Core real-repo bug-fix benchmark.
+- [SWE-bench Multimodal (2024)](https://arxiv.org/abs/2410.03859) - Extends coding eval to visual software artifacts.
+- [SWE-bench Goes Live! (2025)](https://arxiv.org/abs/2505.23419) - Live benchmark operations and methodology insights.
 
 Expansion:
-- [SWE-Gym (2024)](https://arxiv.org/abs/2412.21139) - Training environment for SWE agents/verifiers.
+- [SWE-Gym (2024)](https://arxiv.org/abs/2412.21139)
+- [OmniCode (2026)](https://arxiv.org/abs/2602.02262)
+- [Agent-Diff (2026)](https://arxiv.org/abs/2602.11224)
 
 ## 3) MCP, Tool Use, and Agent Reliability
 
-Core:
-- [MCPMark (2025)](https://arxiv.org/abs/2509.24002) - Real-world MCP benchmark (127 tasks).
-- [τ-bench (2024)](https://arxiv.org/abs/2406.12045) - Tool-agent-user interaction benchmark with pass^k reliability framing.
-- [AgentBench (2023)](https://arxiv.org/abs/2308.03688) - Multi-domain benchmark for LLM agents.
+Top 3 must-read (and why):
+- [MCPMark (2025)](https://arxiv.org/abs/2509.24002) - Current high-signal MCP stress test (real tasks, hard ceilings).
+- [τ-bench (2024)](https://arxiv.org/abs/2406.12045) - Reliability framing with pass^k in interactive tool workflows.
+- [Towards a Science of AI Agent Reliability (2026)](https://arxiv.org/abs/2602.16666) - Reliability science framing beyond headline accuracy.
 
 Expansion:
-- [GAIA (2023)](https://arxiv.org/abs/2311.12983) - Tool-heavy general-assistant benchmark.
+- [AgentBench (2023)](https://arxiv.org/abs/2308.03688)
+- [MCP-Bench (2025)](https://arxiv.org/abs/2508.20453)
+- [MCPAgentBench (2025)](https://arxiv.org/abs/2512.24565)
+- [MCPToolBench++ (2025)](https://arxiv.org/abs/2508.07575)
 
 ## 4) Web and Computer-Use Agents
 
-Core:
-- [WebArena (2023)](https://arxiv.org/abs/2307.13854) - Realistic web-task environment.
-- [VisualWebArena (2024)](https://arxiv.org/abs/2401.13649) - Visually grounded web-agent benchmark.
-- [OSWorld (2024)](https://arxiv.org/abs/2404.07972) - Open-ended desktop computer-use benchmark.
+Top 3 must-read (and why):
+- [WebArena (2023)](https://arxiv.org/abs/2307.13854) - Realistic browser-task benchmark baseline.
+- [VisualWebArena (2024)](https://arxiv.org/abs/2401.13649) - Adds visual grounding pressure to web-agent evals.
+- [OSWorld (2024)](https://arxiv.org/abs/2404.07972) - Open-ended desktop environment with strong realism.
+
+Expansion:
+- [OS-Harm (2025)](https://arxiv.org/abs/2506.14866)
 
 ## 5) Context Engineering and Memory
 
-Core:
-- [RAG (2020)](https://arxiv.org/abs/2005.11401) - Retrieval-augmented generation foundation.
-- [MemGPT (2023)](https://arxiv.org/abs/2310.08560) - OS-inspired memory hierarchy for LLM agents.
-- [Self-RAG (2023)](https://arxiv.org/abs/2310.11511) - Retrieval + critique loop.
+Top 3 must-read (and why):
+- [RAG (2020)](https://arxiv.org/abs/2005.11401) - Retrieval architecture baseline for external memory.
+- [MemGPT (2023)](https://arxiv.org/abs/2310.08560) - Memory tiering and virtual-context perspective.
+- [Self-RAG (2023)](https://arxiv.org/abs/2310.11511) - Retrieval with self-critique control loop.
 
 Expansion:
-- [Lost in the Middle (2023)](https://arxiv.org/abs/2307.03172) - Long-context retrieval/placement failure mode.
-- [RETRO (2021)](https://arxiv.org/abs/2112.04426) - Retrieval-heavy architecture with external memory.
-- [kNN-LM (2020)](https://arxiv.org/abs/1911.00172) - Non-parametric memory at inference time.
+- [Lost in the Middle (2023)](https://arxiv.org/abs/2307.03172)
+- [RETRO (2021)](https://arxiv.org/abs/2112.04426)
+- [kNN-LM (2020)](https://arxiv.org/abs/1911.00172)
+- [Evaluating Very Long-Term Conversational Memory of LLM Agents (2024)](https://arxiv.org/abs/2402.17753)
+- [Mem-Gallery (2026)](https://arxiv.org/abs/2601.03515)
 
 ## 6) Prompt and Programmatic Prompt Engineering
 
-Core:
-- [Chain-of-Thought (2022)](https://arxiv.org/abs/2201.11903)
-- [Self-Consistency (2022)](https://arxiv.org/abs/2203.11171)
-- [Tree of Thoughts (2023)](https://arxiv.org/abs/2305.10601)
+Top 3 must-read (and why):
+- [Chain-of-Thought (2022)](https://arxiv.org/abs/2201.11903) - Core reasoning prompt primitive.
+- [Self-Consistency (2022)](https://arxiv.org/abs/2203.11171) - Robustness boost for reasoning via sampling.
+- [Tree of Thoughts (2023)](https://arxiv.org/abs/2305.10601) - Deliberate search over candidate thoughts.
 
 Expansion:
-- [DSPy (2023)](https://arxiv.org/abs/2310.03714) - Compiling declarative LM programs.
+- [DSPy (2023)](https://arxiv.org/abs/2310.03714)
 
 ## 7) Security and Robustness
 
-Core:
-- [Universal and Transferable Adversarial Attacks on Aligned LMs (2023)](https://arxiv.org/abs/2307.15043)
-- [StruQ (2024)](https://arxiv.org/abs/2402.06363) - Structured-query defense against prompt injection.
-- [SecAlign (2024)](https://arxiv.org/abs/2410.05451) - Preference-optimization defense for prompt injection.
+Top 3 must-read (and why):
+- [Universal and Transferable Adversarial Attacks on Aligned LMs (2023)](https://arxiv.org/abs/2307.15043) - Baseline offensive pressure test.
+- [StruQ (2024)](https://arxiv.org/abs/2402.06363) - Structured prompt/query defense pattern.
+- [SecAlign (2024)](https://arxiv.org/abs/2410.05451) - Alignment-based defense for prompt injection.
+
+Expansion:
+- [Too Helpful to Be Safe (2026)](https://arxiv.org/abs/2601.10758)
+- [MCP-in-SoS (2026)](https://arxiv.org/abs/2603.10194)
+- [Compatibility at a Cost (2026)](https://arxiv.org/abs/2603.10163)
 
 ## 8) Voice and Multimodal Agents
 
-Core:
-- [Whisper / Robust Speech Recognition via Large-Scale Weak Supervision (2022)](https://arxiv.org/abs/2212.04356)
-- [Visual Instruction Tuning (LLaVA, 2023)](https://arxiv.org/abs/2304.08485)
+Top 3 must-read (and why):
+- [Whisper / Robust Speech Recognition via Large-Scale Weak Supervision (2022)](https://arxiv.org/abs/2212.04356) - Reliable speech baseline for voice agents.
+- [Visual Instruction Tuning (LLaVA, 2023)](https://arxiv.org/abs/2304.08485) - Core multimodal instruction-following pattern.
+- [Mem-Gallery (2026)](https://arxiv.org/abs/2601.03515) - Long-horizon multimodal conversational memory benchmark.
 
 ## 9) Evaluation Science and LLM-as-a-Judge
 
-Core:
-- [HELM (2022)](https://arxiv.org/abs/2211.09110) - Holistic evaluation framework.
-- [MT-Bench and Chatbot Arena / LLM-as-a-Judge analysis (2023)](https://arxiv.org/abs/2306.05685)
-- [Systematic Evaluation of LLM-as-a-Judge (2024)](https://arxiv.org/abs/2408.13006)
+Top 3 must-read (and why):
+- [HELM (2022)](https://arxiv.org/abs/2211.09110) - Holistic evaluation methodology.
+- [MT-Bench / Chatbot Arena LLM-as-a-Judge analysis (2023)](https://arxiv.org/abs/2306.05685) - Judge-model strengths/limits in practice.
+- [Systematic Evaluation of LLM-as-a-Judge (2024)](https://arxiv.org/abs/2408.13006) - Template effects and judge reliability caveats.
 
 ## 10) Quant and Trading Agents
 
-Core:
-- [FinRL Library (2020)](https://arxiv.org/abs/2011.09607)
-- [FinRL Framework (2021)](https://arxiv.org/abs/2111.09395)
-- [FinRL-Podracer (2021)](https://arxiv.org/abs/2111.05188)
+Top 3 must-read (and why):
+- [FinRL Library (2020)](https://arxiv.org/abs/2011.09607) - Practical DRL trading baseline.
+- [FinRL Framework (2021)](https://arxiv.org/abs/2111.09395) - End-to-end automation framing for quant agents.
+- [FinRL-Podracer (2021)](https://arxiv.org/abs/2111.05188) - Throughput/scalability for production-ish experiments.
 
 Expansion:
 - [Large Language Models in Finance: A Survey (2023)](https://arxiv.org/abs/2311.10723)
 - [LLM Agent in Financial Trading: A Survey (2024)](https://arxiv.org/abs/2408.06361)
 
-## 11) Blockchain Identity, Payments, and DeFi Adjacent Research
+## 11) Blockchain Identity, Payments, and DeFi-Adjacent Research
 
-Core:
-- [Deployment of a Blockchain-Based Self-Sovereign Identity (2018)](https://arxiv.org/abs/1806.01926)
-- [Design Patterns for Blockchain-based Self-Sovereign Identity (2020)](https://arxiv.org/abs/2005.12112)
-- [Decentralized Finance (2023)](https://arxiv.org/abs/2304.01918)
+Top 3 must-read (and why):
+- [Deployment of a Blockchain-Based Self-Sovereign Identity (2018)](https://arxiv.org/abs/1806.01926) - SSI implementation grounding.
+- [Design Patterns for Blockchain-based Self-Sovereign Identity (2020)](https://arxiv.org/abs/2005.12112) - Reusable SSI architecture patterns.
+- [Decentralized Finance (2023)](https://arxiv.org/abs/2304.01918) - Broad DeFi systems framing.
 
 Expansion:
-- [Is DeFi Actually Decentralized? (Aave network analysis, 2022)](https://arxiv.org/abs/2206.08401)
-- [Smart-LLaMA (2024)](https://arxiv.org/abs/2411.06221) - LLM post-training for smart-contract vulnerability detection.
+- [Is DeFi Actually Decentralized? (2022)](https://arxiv.org/abs/2206.08401)
+- [Smart-LLaMA (2024)](https://arxiv.org/abs/2411.06221)
 - [Generative LLM Usage in Smart-Contract Vulnerability Detection (2025)](https://arxiv.org/abs/2504.04685)
 
 ---
 
-Suggested maintenance cadence:
-- Monthly: refresh benchmark-centric categories (MCP/tool-use/coding/computer-use).
-- Quarterly: refresh foundational categories (memory/context/security/multimodal/quant).
-- Keep this map opinionated: prefer papers with clear methods, reproducibility artifacts, and practical operator takeaways.
+## Recent ArXiv Watchlist (last ~90 days, as of 2026-03-12)
+
+Note: this watchlist is intentionally short and high-signal; verify final inclusion quality when papers leave preprint churn.
+
+- [Towards a Science of AI Agent Reliability (2026-02)](https://arxiv.org/abs/2602.16666)
+- [The Convergence of Schema-Guided Dialogue Systems and the Model Context Protocol (2026-02)](https://arxiv.org/abs/2602.18764)
+- [Too Helpful to Be Safe: User-Mediated Attacks on Planning and Web-Use Agents (2026-01)](https://arxiv.org/abs/2601.10758)
+- [Mem-Gallery: Benchmarking Multimodal Long-Term Conversational Memory for MLLM Agents (2026-01)](https://arxiv.org/abs/2601.03515)
+- [OmniCode: A Benchmark for Evaluating Software Engineering Agents (2026-02)](https://arxiv.org/abs/2602.02262)
+- [Agent-Diff: Benchmarking LLM Agents on Enterprise API Tasks via Code Execution with State-Diff-Based Evaluation (2026-02)](https://arxiv.org/abs/2602.11224)
+- [MCP-in-SoS: Risk assessment framework for open-source MCP servers (2026-03)](https://arxiv.org/abs/2603.10194)
+- [Compatibility at a Cost: Systematic Discovery and Exploitation of MCP Clause-Compliance Vulnerabilities (2026-03)](https://arxiv.org/abs/2603.10163)
+
+## Monthly Refresh Workflow (template)
+
+Use this on the first week of each month:
+
+1) Pull candidates
+- Query arXiv for each category using category keywords and date filter for last 45 days.
+- Keep a raw scratch list (20-40 papers total).
+
+2) Apply inclusion gate
+- Keep papers that pass at least 3 of 5:
+  - Clear method/benchmark contribution
+  - Reproducibility artifacts (code/data/eval details)
+  - Strong operator relevance (how to build, test, secure, deploy)
+  - Non-trivial novelty versus existing map
+  - Cross-category leverage (useful outside one niche)
+
+3) Curate final set
+- Promote 1-3 papers per category max per month.
+- Move low-signal or superseded papers to an archive list.
+
+4) Update repo docs
+- Update this map.
+- Update README only if a paper changes the practical narrative (for example, reliability ceilings, new benchmark standard).
+
+5) Log rationale
+- For each promoted paper, add one-line "why it matters" in commit message or PR body.
+
+Suggested commit format:
+- docs(research): monthly arxiv refresh YYYY-MM

--- a/guides/arxiv-deep-research-map.md
+++ b/guides/arxiv-deep-research-map.md
@@ -1,0 +1,118 @@
+# ArXiv Deep Research Map for Agent Cortex
+
+Purpose: a high-signal arXiv reading map that deepens coverage across the major categories in this repo.
+
+How to use this:
+- Start with "Core" papers in each category.
+- Use "Expansion" papers when designing or benchmarking production systems.
+- Treat benchmark scores as moving targets; always check live leaderboards and method cards.
+
+## 1) Agent Frameworks and Reasoning Loops
+
+Core:
+- [ReAct (2022)](https://arxiv.org/abs/2210.03629) - Reasoning + acting loop for tool-using agents.
+- [Reflexion (2023)](https://arxiv.org/abs/2303.11366) - Verbal self-feedback for iterative improvement.
+- [Toolformer (2023)](https://arxiv.org/abs/2302.04761) - Self-supervised tool-use behavior induction.
+
+Expansion:
+- [Generative Agents (2023)](https://arxiv.org/abs/2304.03442) - Memory/planning/reflection architecture in sandbox worlds.
+- [A Survey on LLM-based Autonomous Agents (2023)](https://arxiv.org/abs/2308.11432) - Broad architecture landscape.
+
+## 2) Coding Agents
+
+Core:
+- [SWE-bench (2023)](https://arxiv.org/abs/2310.06770) - Real GitHub issue resolution benchmark.
+- [SWE-bench Multimodal (2024)](https://arxiv.org/abs/2410.03859) - Visual software understanding extension.
+- [SWE-bench Goes Live! (2025)](https://arxiv.org/abs/2505.23419) - Live benchmark methodology and updates.
+
+Expansion:
+- [SWE-Gym (2024)](https://arxiv.org/abs/2412.21139) - Training environment for SWE agents/verifiers.
+
+## 3) MCP, Tool Use, and Agent Reliability
+
+Core:
+- [MCPMark (2025)](https://arxiv.org/abs/2509.24002) - Real-world MCP benchmark (127 tasks).
+- [τ-bench (2024)](https://arxiv.org/abs/2406.12045) - Tool-agent-user interaction benchmark with pass^k reliability framing.
+- [AgentBench (2023)](https://arxiv.org/abs/2308.03688) - Multi-domain benchmark for LLM agents.
+
+Expansion:
+- [GAIA (2023)](https://arxiv.org/abs/2311.12983) - Tool-heavy general-assistant benchmark.
+
+## 4) Web and Computer-Use Agents
+
+Core:
+- [WebArena (2023)](https://arxiv.org/abs/2307.13854) - Realistic web-task environment.
+- [VisualWebArena (2024)](https://arxiv.org/abs/2401.13649) - Visually grounded web-agent benchmark.
+- [OSWorld (2024)](https://arxiv.org/abs/2404.07972) - Open-ended desktop computer-use benchmark.
+
+## 5) Context Engineering and Memory
+
+Core:
+- [RAG (2020)](https://arxiv.org/abs/2005.11401) - Retrieval-augmented generation foundation.
+- [MemGPT (2023)](https://arxiv.org/abs/2310.08560) - OS-inspired memory hierarchy for LLM agents.
+- [Self-RAG (2023)](https://arxiv.org/abs/2310.11511) - Retrieval + critique loop.
+
+Expansion:
+- [Lost in the Middle (2023)](https://arxiv.org/abs/2307.03172) - Long-context retrieval/placement failure mode.
+- [RETRO (2021)](https://arxiv.org/abs/2112.04426) - Retrieval-heavy architecture with external memory.
+- [kNN-LM (2020)](https://arxiv.org/abs/1911.00172) - Non-parametric memory at inference time.
+
+## 6) Prompt and Programmatic Prompt Engineering
+
+Core:
+- [Chain-of-Thought (2022)](https://arxiv.org/abs/2201.11903)
+- [Self-Consistency (2022)](https://arxiv.org/abs/2203.11171)
+- [Tree of Thoughts (2023)](https://arxiv.org/abs/2305.10601)
+
+Expansion:
+- [DSPy (2023)](https://arxiv.org/abs/2310.03714) - Compiling declarative LM programs.
+
+## 7) Security and Robustness
+
+Core:
+- [Universal and Transferable Adversarial Attacks on Aligned LMs (2023)](https://arxiv.org/abs/2307.15043)
+- [StruQ (2024)](https://arxiv.org/abs/2402.06363) - Structured-query defense against prompt injection.
+- [SecAlign (2024)](https://arxiv.org/abs/2410.05451) - Preference-optimization defense for prompt injection.
+
+## 8) Voice and Multimodal Agents
+
+Core:
+- [Whisper / Robust Speech Recognition via Large-Scale Weak Supervision (2022)](https://arxiv.org/abs/2212.04356)
+- [Visual Instruction Tuning (LLaVA, 2023)](https://arxiv.org/abs/2304.08485)
+
+## 9) Evaluation Science and LLM-as-a-Judge
+
+Core:
+- [HELM (2022)](https://arxiv.org/abs/2211.09110) - Holistic evaluation framework.
+- [MT-Bench and Chatbot Arena / LLM-as-a-Judge analysis (2023)](https://arxiv.org/abs/2306.05685)
+- [Systematic Evaluation of LLM-as-a-Judge (2024)](https://arxiv.org/abs/2408.13006)
+
+## 10) Quant and Trading Agents
+
+Core:
+- [FinRL Library (2020)](https://arxiv.org/abs/2011.09607)
+- [FinRL Framework (2021)](https://arxiv.org/abs/2111.09395)
+- [FinRL-Podracer (2021)](https://arxiv.org/abs/2111.05188)
+
+Expansion:
+- [Large Language Models in Finance: A Survey (2023)](https://arxiv.org/abs/2311.10723)
+- [LLM Agent in Financial Trading: A Survey (2024)](https://arxiv.org/abs/2408.06361)
+
+## 11) Blockchain Identity, Payments, and DeFi Adjacent Research
+
+Core:
+- [Deployment of a Blockchain-Based Self-Sovereign Identity (2018)](https://arxiv.org/abs/1806.01926)
+- [Design Patterns for Blockchain-based Self-Sovereign Identity (2020)](https://arxiv.org/abs/2005.12112)
+- [Decentralized Finance (2023)](https://arxiv.org/abs/2304.01918)
+
+Expansion:
+- [Is DeFi Actually Decentralized? (Aave network analysis, 2022)](https://arxiv.org/abs/2206.08401)
+- [Smart-LLaMA (2024)](https://arxiv.org/abs/2411.06221) - LLM post-training for smart-contract vulnerability detection.
+- [Generative LLM Usage in Smart-Contract Vulnerability Detection (2025)](https://arxiv.org/abs/2504.04685)
+
+---
+
+Suggested maintenance cadence:
+- Monthly: refresh benchmark-centric categories (MCP/tool-use/coding/computer-use).
+- Quarterly: refresh foundational categories (memory/context/security/multimodal/quant).
+- Keep this map opinionated: prefer papers with clear methods, reproducibility artifacts, and practical operator takeaways.


### PR DESCRIPTION
## Summary
- add benchmark reality-check framing in README (MCPMark, τ-bench, OSWorld, WebArena, GAIA)
- expand `guides/arxiv-deep-research-map.md` with top 3 must-read papers per category and why each matters
- add recent ~90-day watchlist section
- add repeatable monthly refresh workflow template
- update README copy to reflect the deeper arXiv map scope

## Files changed
- `README.md`
- `guides/arxiv-deep-research-map.md`

## Validation
- docs-only change; no code/runtime impact
