### PR TITLE
Add NoPipe — NFT-gated RPC infrastructure for AI agents on Base

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,6 +405,7 @@ Payment protocols and infrastructure for autonomous agent transactions.
 - [Coinbase Agentic Wallets](https://www.coinbase.com/developer-platform/discover/launches/agentic-wallets) - Wallet infrastructure for AI agents with programmable spending limits.
 - [Google A2A x402 Extension](https://github.com/google-agentic-commerce/a2a-x402) - Cryptocurrency payments for the Agent-to-Agent protocol via x402.
 - [lobster.cash](https://www.lobster.cash) - Agent payment solution on Solana with Visa Intelligent Commerce integration by Crossmint.
+- [NoPipe](https://github.com/ve5p3r/nopipe) - NFT-gated RPC infrastructure for AI agents on Base with non-custodial swap execution and soulbound operator access control.
 - [Request Network](https://request.network) - Crypto-native invoicing and payment request rails for agent billing workflows.
 - [Solana Pay](https://solanapay.com) - Open payments standard for Solana-based checkout and transfer flows.
 - [Superfluid](https://superfluid.org) - Streaming payment primitives for machine-to-machine and agent subscriptions.


### PR DESCRIPTION
Adds [NoPipe](https://github.com/ve5p3r/nopipe) to the Agent Payments section.

NoPipe provides trustless RPC infrastructure for AI agents on Base — NFT-gated access control (soulbound OperatorNFT with 100 genesis seats), non-custodial swap execution via Aerodrome/Uniswap, and USDC subscription management. Live on Base mainnet.

- Site: https://nopipe.io
- Contracts verified on Basescan
- MIT licensed