### PR TITLE
Add AIP (Agent Identity Protocol) to Agent Identity and Wallets

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,6 +396,7 @@ On-chain identity, wallets, and trust infrastructure for autonomous AI agents.
 - [Squads Protocol](https://github.com/Squads-Protocol/v4) - Multisig and smart account protocol for Solana agents.
 - [Turnkey](https://www.turnkey.com) - Secure key infrastructure for programmatic wallet management.
 - [UCAN](https://github.com/ucan-wg/spec) - User-controlled authorization for decentralized agent capabilities.
+- [AIP (Agent Identity Protocol)](https://github.com/The-Nexus-Guard/aip) - Cryptographic identity, trust vouching, and encrypted messaging for AI agents. Ed25519 signatures, W3C Verifiable Credentials, behavioral trust scoring (PDR). `pip install aip-identity`.
 
 ## Agent Payments
 


### PR DESCRIPTION
AIP provides cryptographic identity infrastructure for AI agents without blockchain dependency.

**What it does:**
- Ed25519 keypair-based identity (DID generation, challenge-response verification)
- Trust vouching with W3C Verifiable Credentials
- Encrypted agent-to-agent messaging (NaCl SealedBox)
- Behavioral trust scoring via PDR (Probabilistic Delegation Reliability)
- Cross-protocol DID resolution (`did:aip`, `did:key`, `did:web`, `did:aps`)

**Why it fits this section:** Complements the existing blockchain-based identity entries (Coinbase AgentKit, Privy, SIWE) by providing an off-chain alternative. Agents that need identity but not wallets can use AIP standalone; agents that need both can combine AIP identity with on-chain wallets.

- **PyPI:** 3,300+ monthly installs
- **Tests:** 533 passing
- **License:** MIT
- **GitHub:** https://github.com/The-Nexus-Guard/aip