### PR TITLE
ci: add catalog-driven curation checks and README generator

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -27,3 +27,7 @@ Which section does this belong to?
 ### Why?
 
 Brief justification for why this entry belongs on the list.
+
+### Intentional cross-listings (if any)
+
+If this PR adds a resource that already appears in another section, explain why the overlap is intentional and useful.

--- a/.github/curation/section_floors.json
+++ b/.github/curation/section_floors.json
@@ -1,0 +1,16 @@
+{
+  "version": "1.0.0",
+  "note": "Minimum section sizes; update intentionally when taxonomy is revised.",
+  "floors": {
+    "Agent Frameworks": 24,
+    "Coding Agents": 20,
+    "MCP Ecosystem": 16,
+    "Agent Harnessing and Evaluation": 24,
+    "Agent Security and Robustness": 10,
+    "Agent Configs and Dotfiles": 8,
+    "Skill Engineering and Playbooks": 10,
+    "Knowledge Graphs and Memory": 18,
+    "Agent Observability and Testing": 16,
+    "Hermes Stack": 8
+  }
+}

--- a/.github/scripts/check_cross_listing_rationale.py
+++ b/.github/scripts/check_cross_listing_rationale.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+README = Path('README.md')
+
+
+def duplicate_url_counts(markdown: str) -> dict[str, int]:
+    section = None
+    counts: dict[str, int] = {}
+    for line in markdown.splitlines():
+        h = re.match(r'^##\s+(.+)$', line)
+        if h:
+            section = h.group(1).strip()
+            continue
+        m = re.match(r'^- \[[^\]]+\]\((https?://[^\)]+)\) - ', line)
+        if m and section:
+            url = m.group(1)
+            counts[url] = counts.get(url, 0) + 1
+    return counts
+
+
+def load_base_readme(base_ref: str) -> str:
+    cmd = ['git', 'show', f'origin/{base_ref}:README.md']
+    res = subprocess.run(cmd, capture_output=True, text=True)
+    if res.returncode != 0:
+        raise RuntimeError(f'Unable to load base README from origin/{base_ref}: {res.stderr.strip()}')
+    return res.stdout
+
+
+def main() -> int:
+    event = os.getenv('GITHUB_EVENT_NAME', '')
+    if event != 'pull_request':
+        print('Skipping cross-listing rationale check outside pull_request events.')
+        return 0
+
+    base_ref = os.getenv('BASE_REF', 'main')
+    pr_body = os.getenv('PR_BODY', '')
+
+    current = README.read_text(encoding='utf-8')
+    base = load_base_readme(base_ref)
+
+    current_dups = duplicate_url_counts(current)
+    base_dups = duplicate_url_counts(base)
+
+    increased = []
+    for url, count in current_dups.items():
+        base_count = base_dups.get(url, 0)
+        if count > 1 and count > base_count:
+            increased.append((url, base_count, count))
+
+    if not increased:
+        print('No new cross-listings introduced.')
+        return 0
+
+    if 'Intentional cross-listings' not in pr_body:
+        print('New cross-listings detected but PR body is missing required rationale section.')
+        print('Add a section titled "Intentional cross-listings" to explain why duplication is useful.')
+        print('\nDetected new cross-listings:')
+        for url, before, after in increased:
+            print(f'- {url}: {before} -> {after}')
+        return 1
+
+    print('Cross-listing rationale present in PR body.')
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/.github/scripts/check_section_floors.py
+++ b/.github/scripts/check_section_floors.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+import json
+import re
+import sys
+from pathlib import Path
+
+README = Path('README.md')
+FLOORS = Path('.github/curation/section_floors.json')
+
+
+def section_counts(text: str) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    section = None
+    for line in text.splitlines():
+        m = re.match(r'^##\s+(.+)$', line)
+        if m:
+            section = m.group(1).strip()
+            counts.setdefault(section, 0)
+            continue
+        m = re.match(r'^- \[[^\]]+\]\(([^\)]+)\) - ', line)
+        if m and section:
+            counts[section] = counts.get(section, 0) + 1
+    return counts
+
+
+def main() -> int:
+    floors = json.loads(FLOORS.read_text(encoding='utf-8'))
+    counts = section_counts(README.read_text(encoding='utf-8'))
+
+    violations = []
+    for section, min_count in floors.get('floors', {}).items():
+        actual = counts.get(section, 0)
+        if actual < min_count:
+            violations.append((section, min_count, actual))
+
+    if violations:
+        print('Section floor violations detected:\n')
+        for section, minimum, actual in violations:
+            print(f'- {section}: expected >= {minimum}, found {actual}')
+        return 1
+
+    print('Section floors OK.')
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/.github/scripts/generate_readme_from_catalog.py
+++ b/.github/scripts/generate_readme_from_catalog.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+import json
+from pathlib import Path
+
+README = Path('README.md')
+CATALOG = Path('data/resources.json')
+START = '<!-- RESOURCES:START -->'
+END = '<!-- RESOURCES:END -->'
+
+
+def render_sections(catalog: dict) -> list[str]:
+    lines: list[str] = []
+    for section in catalog['sections']:
+        lines.append(f"## {section['name']}")
+        for item in section['items']:
+            if item['type'] == 'entry':
+                lines.append(f"- [{item['name']}]({item['url']}) - {item['description']}")
+            else:
+                lines.append(item['text'])
+    return lines
+
+
+def main() -> int:
+    readme_lines = README.read_text(encoding='utf-8').splitlines()
+    catalog = json.loads(CATALOG.read_text(encoding='utf-8'))
+
+    start_marker = catalog.get('managed_block', {}).get('start_marker', START)
+    end_marker = catalog.get('managed_block', {}).get('end_marker', END)
+
+    if start_marker not in readme_lines or end_marker not in readme_lines:
+        raise SystemExit('README.md is missing managed resource markers')
+
+    sidx = readme_lines.index(start_marker)
+    eidx = readme_lines.index(end_marker)
+    if sidx >= eidx:
+        raise SystemExit('Invalid managed marker ordering in README.md')
+
+    rendered = render_sections(catalog)
+    new_lines = readme_lines[: sidx + 1] + rendered + readme_lines[eidx:]
+    content = '\n'.join(new_lines).rstrip('\n') + '\n'
+    README.write_text(content, encoding='utf-8')
+    print(f'Generated README managed block from {CATALOG}')
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/.github/workflows/awesome-lint.yml
+++ b/.github/workflows/awesome-lint.yml
@@ -4,14 +4,23 @@ on:
   pull_request:
     paths:
       - 'README.md'
+      - 'data/resources.json'
+      - '.github/curation/section_floors.json'
       - '.github/workflows/awesome-lint.yml'
       - '.github/scripts/check_alpha_sections.py'
+      - '.github/scripts/check_section_floors.py'
+      - '.github/scripts/check_cross_listing_rationale.py'
+      - '.github/scripts/generate_readme_from_catalog.py'
   push:
     branches: [main]
     paths:
       - 'README.md'
+      - 'data/resources.json'
+      - '.github/curation/section_floors.json'
       - '.github/workflows/awesome-lint.yml'
       - '.github/scripts/check_alpha_sections.py'
+      - '.github/scripts/check_section_floors.py'
+      - '.github/scripts/generate_readme_from_catalog.py'
 
 jobs:
   awesome-lint:
@@ -19,6 +28,13 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
 
       - name: Set up Node
         uses: actions/setup-node@v4
@@ -29,5 +45,22 @@ jobs:
         continue-on-error: true
         run: npx --yes awesome-lint README.md
 
+      - name: Regenerate README from catalog
+        run: python3 .github/scripts/generate_readme_from_catalog.py
+
+      - name: Ensure README is in sync with catalog
+        run: git diff --exit-code README.md
+
       - name: Check alphabetical order in curated sections
         run: python3 .github/scripts/check_alpha_sections.py README.md
+
+      - name: Enforce section floors
+        run: python3 .github/scripts/check_section_floors.py
+
+      - name: Require rationale for new cross-listings
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_REF: ${{ github.base_ref }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+        run: python3 .github/scripts/check_cross_listing_rationale.py

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,6 +79,19 @@ Rules for cross-listing:
 4. Avoid excessive repetition. If a project appears in more than two sections,
    justify why.
 
+## Catalog-Driven README Workflow
+
+The curated resources block in `README.md` is generated from `data/resources.json`.
+
+When changing entries:
+
+1. Edit `data/resources.json`.
+2. Regenerate README:
+   - `python .github/scripts/generate_readme_from_catalog.py`
+3. Commit both `data/resources.json` and `README.md`.
+
+CI enforces that the generated README matches the catalog.
+
 ## Suggesting a New Section
 
 Open an issue first to discuss whether a new section is warranted. New sections

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Multi-agent orchestration, single-agent SDKs, and runtime frameworks.
 - [Magentic-One](https://github.com/microsoft/autogen/tree/main/python/packages/autogen-magentic-one) - Multi-agent team for complex web and file tasks.
 - [Mastra](https://github.com/mastra-ai/mastra) - TypeScript framework for building AI applications and agents.
 - [Microsoft Agent Framework](https://github.com/microsoft/agent-framework) - Framework for building, orchestrating, and deploying agents with Python and .NET support.
+- [NemoClaw](https://github.com/NVIDIA/NemoClaw) - NVIDIA plugin stack for secure installation and operation of OpenClaw agents.
 - [OpenAI Agents SDK](https://github.com/openai/openai-agents-python) - Official SDK for building agents with OpenAI models.
 - [OpenClaw](https://github.com/openclaw/openclaw) - Self-hosted personal AI agent with multi-platform messaging and skill registry.
 - [Phidata](https://github.com/phidatahq/phidata) - Toolkit for building AI assistants with memory and tools.
@@ -83,8 +84,11 @@ AI agents that write, review, and debug code.
 - [Cursor](https://cursor.com) - AI-first code editor built on VS Code.
 - [Devin](https://devin.ai) - Autonomous software engineering agent by Cognition.
 - [Goose](https://github.com/block/goose) - Autonomous developer agent from Block.
+- [Leanstral](https://mistral.ai/news/leanstral) - Open-source code agent for Lean 4 formal verification from Mistral AI.
+- [Open-SWE](https://github.com/langchain-ai/open-swe) - Open-source asynchronous coding agent from LangChain for software engineering tasks.
 - [OpenCodex](https://github.com/openai/codex) - OpenAI's CLI coding agent.
 - [OpenHands](https://github.com/All-Hands-AI/OpenHands) - Platform for AI software development agents (formerly OpenDevin).
+- [SERA](https://allenai.org/blog/open-coding-agents) - Open 14B-parameter coding agent from Ai2 that adapts to private codebases.
 - [SWE-Agent](https://github.com/princeton-nlp/SWE-agent) - Agent for automatically resolving GitHub issues.
 - [Windsurf](https://codeium.com/windsurf) - AI-native IDE by Codeium with agentic flows.
 
@@ -112,6 +116,7 @@ Agents with voice, vision, and multimodal capabilities.
 - [ElevenLabs](https://github.com/elevenlabs/elevenlabs-python) - Text-to-speech and voice cloning API for agent voice interfaces.
 - [LiveKit Agents](https://github.com/livekit/agents) - Framework for building real-time multimodal AI agents.
 - [Pipecat](https://github.com/pipecat-ai/pipecat) - Framework for building voice and multimodal conversational agents.
+- [Sesame CSM](https://github.com/SesameAILabs/csm) - Conversational speech model for real-time voice agent interactions.
 - [TEN Framework](https://github.com/TEN-framework/ten-framework) - Open-source framework for conversational voice AI agents.
 - [Ultravox](https://github.com/fixie-ai/ultravox) - Fast multimodal LLM for real-time voice AI.
 - [Vapi](https://vapi.ai) - Platform for building and deploying voice AI agents.
@@ -137,6 +142,10 @@ Hermes Agent runtime, deployment rails, and operator resources.
 Terminal-based agent interfaces and developer tools.
 
 - [Claude Code](https://docs.anthropic.com/en/docs/claude-code) - Agentic CLI that operates directly in the terminal.
+- [Claude Squad](https://github.com/smtg-ai/claude-squad) - tmux-based harness for running and managing multiple Claude Code sessions side-by-side.
+- [cmux](https://github.com/manaflow-ai/cmux) - Ghostty-based macOS terminal with vertical tabs and notifications for AI coding agents.
+- [Crush](https://github.com/charmbracelet/crush) - Agentic coding TUI from Charmbracelet with multi-provider support and LSP awareness.
+- [dmux](https://github.com/standardagents/dmux) - Dev agent multiplexer for managing coding agents across git worktrees.
 - [Gemini CLI](https://github.com/google-gemini/gemini-cli) - Google's command-line interface for Gemini models.
 - [Glow](https://github.com/charmbracelet/glow) - Terminal Markdown renderer useful for agent output.
 - [Hermes Agent](https://github.com/NousResearch/hermes-agent) - CLI and gateway agent runtime with tools, memory, delegation, and automation support.
@@ -144,7 +153,9 @@ Terminal-based agent interfaces and developer tools.
 - [lazygit](https://github.com/jesseduffield/lazygit) - Terminal UI for git commonly paired with coding agents.
 - [llm](https://github.com/simonw/llm) - CLI tool for interacting with LLMs from the terminal.
 - [aichat](https://github.com/sigoden/aichat) - All-in-one LLM CLI with chat, shell assistant, RAG, and agent features.
+- [OpenCode](https://github.com/opencode-ai/opencode) - Open-source terminal coding agent with multi-provider support and LSP integration.
 - [OpenCodex](https://github.com/openai/codex) - Lightweight CLI coding agent from OpenAI.
+- [Plandex](https://github.com/plandex-ai/plandex) - Plan-first CLI agent for multi-file features with structured steps and large context.
 - [sgpt](https://github.com/tbckr/sgpt) - Command-line productivity tool powered by LLMs.
 - [tmux](https://github.com/tmux/tmux) - Terminal multiplexer for running agents in persistent sessions.
 - [Warp](https://www.warp.dev) - Modern terminal with built-in AI assistance.
@@ -161,6 +172,7 @@ Execution sandboxes and runtime platforms for safely running agent actions and g
 - [gVisor](https://github.com/google/gvisor) - Application kernel for containers that adds a strong isolation boundary.
 - [Kata Containers](https://github.com/kata-containers/kata-containers) - Lightweight VM-based container runtime for stronger workload isolation.
 - [Modal](https://modal.com) - Serverless compute platform often used for running agent workloads and tools.
+- [Morph](https://morphcloud.com) - Cloud sandbox runtime for AI agents with snapshot/restore and time-travel debugging.
 - [RunPod Python SDK](https://github.com/runpod/runpod-python) - Python SDK for RunPod serverless and worker-based AI workloads.
 
 ## MCP Ecosystem
@@ -169,6 +181,7 @@ Model Context Protocol servers, clients, and tooling.
 
 - [Awesome MCP Servers](https://github.com/punkpeye/awesome-mcp-servers) - Curated list of MCP server implementations.
 - [Chrome DevTools MCP](https://github.com/ChromeDevTools/chrome-devtools-mcp) - Official Chrome DevTools MCP server for coding and browser automation agents.
+- [Context7 MCP](https://github.com/upstash/context7) - Most-used MCP server in 2026; provides up-to-date library documentation to agents.
 - [FastMCP](https://github.com/PrefectHQ/fastmcp) - Pythonic framework for building MCP servers and clients quickly.
 - [GitHub MCP Server](https://github.com/github/github-mcp-server) - Official MCP server for GitHub workflows and repository actions.
 - [mcp](https://github.com/modelcontextprotocol/servers) - Official reference MCP server implementations.
@@ -178,6 +191,7 @@ Model Context Protocol servers, clients, and tooling.
 - [MCP Inspector](https://github.com/modelcontextprotocol/inspector) - Official inspector and debugging tool for MCP servers.
 - [MCP Python SDK](https://github.com/modelcontextprotocol/python-sdk) - Official Python SDK for building MCP servers.
 - [MCP Registry](https://github.com/modelcontextprotocol/registry) - Community registry service for discovering MCP servers.
+- [MCP Roadmap 2026](https://blog.modelcontextprotocol.io/posts/2026-mcp-roadmap/) - Official 2026 roadmap covering remote-first servers, discoverability, and enterprise auth.
 - [MCP Rust SDK](https://github.com/modelcontextprotocol/rust-sdk) - Official Rust SDK for building MCP servers.
 - [MCP Spec](https://modelcontextprotocol.io/specification) - Official Model Context Protocol specification.
 - [MCP Specification Repo](https://github.com/modelcontextprotocol/modelcontextprotocol) - Canonical specification and documentation repository.
@@ -190,13 +204,14 @@ Model Context Protocol servers, clients, and tooling.
 Instruction-writing craft: system prompts, response framing, and reusable prompt templates.
 Focus here on *what to ask and how to phrase it* at the prompt layer.
 
+- [Anthropic: 2026 Agentic Coding Trends Report (PDF)](https://resources.anthropic.com/hubfs/2026%20Agentic%20Coding%20Trends%20Report.pdf) - Data-driven analysis of how coding agents reshape software development.
 - [Anthropic Prompt Library](https://docs.anthropic.com/en/prompt-library) - Official prompt examples from Anthropic.
 - [awesome-chatgpt-prompts](https://github.com/f/awesome-chatgpt-prompts) - Collection of prompt examples for ChatGPT.
 - [Claude System Prompts](https://docs.anthropic.com/en/docs/build-with-claude/prompt-engineering) - Guide to writing effective system prompts.
-- [OpenAI Prompt Engineering Guide](https://platform.openai.com/docs/guides/prompt-engineering) - Official guide to designing reliable prompts and instruction patterns.
 - [DSPy](https://github.com/stanfordnlp/dspy) - Framework for programming with foundation models instead of prompting.
 - [fabric](https://github.com/danielmiessler/fabric) - Framework for augmenting humans using AI with curated prompts.
 - [LangChain Hub](https://smith.langchain.com/hub) - Community-driven prompt and chain sharing platform.
+- [OpenAI Prompt Engineering Guide](https://platform.openai.com/docs/guides/prompt-engineering) - Official guide to designing reliable prompts and instruction patterns.
 - [Promptfoo](https://github.com/promptfoo/promptfoo) - Testing and evaluation framework for LLM prompts.
 - [System Prompts](https://github.com/mustvlad/ChatGPT-System-Prompts) - Collection of system prompts for various AI models.
 
@@ -255,6 +270,7 @@ Focus here on *what information the model gets, when, and in what form*.
 - [Anthropic: Effective Harnesses for Long-Running Agents](https://www.anthropic.com/engineering/effective-harnesses-for-long-running-agents) - Patterns for long-horizon orchestration and reliability.
 - [LangChain: Context Engineering for Agents](https://blog.langchain.com/context-engineering-for-agents/) - Practical taxonomy for writing, selecting, compressing, and isolating context.
 - [Manus: Context Engineering for AI Agents](https://manus.im/blog/Context-Engineering-for-AI-Agents-Lessons-from-Building-Manus) - Practitioner lessons from building production autonomous workflows.
+- [Martin Fowler: Harness Engineering](https://martinfowler.com/articles/exploring-gen-ai/harness-engineering.html) - Practitioner-oriented analysis of harness-layer reliability patterns.
 - [OpenAI Evals Guide](https://platform.openai.com/docs/guides/evals) - Official framework for building eval loops and quality gates.
 - [OpenAI Cookbook: Getting Started with Evals](https://developers.openai.com/cookbook/examples/evaluation/getting_started_with_openai_evals) - Practical eval setup walkthrough.
 - [RAG (Lewis et al., 2020)](https://arxiv.org/abs/2005.11401) - Foundational retrieval-augmented generation paper.
@@ -308,6 +324,7 @@ Safety, red-teaming, and robustness tools for hardening agent behavior.
 - [NeMo Guardrails](https://github.com/NVIDIA-NeMo/Guardrails) - Toolkit for adding programmable safety and policy guardrails to LLM systems.
 - [Promptfoo](https://github.com/promptfoo/promptfoo) - Red-teaming and robustness testing toolkit for LLM systems.
 - [PyRIT](https://github.com/Azure/PyRIT) - Python Risk Identification Tool for proactively testing generative AI security risks.
+- [Qualys TotalAI MCP Security](https://blog.qualys.com/product-tech/2026/03/19/mcp-servers-shadow-it-ai-qualys-totalai-2026) - MCP server security assessment and shadow IT detection for enterprise environments.
 
 ## Agent Configs and Dotfiles
 
@@ -320,16 +337,22 @@ Configuration files and workflow examples for AI coding tools.
 - [Cursor Starter Configs](cursorrules/) - Ready-to-use .cursorrules and rule files for Cursor projects.
 - [CursorDirectory](https://cursor.directory) - Community-shared Cursor rules and configurations.
 - [dotfiles](https://dotfiles.github.io) - Guide to managing dotfiles including agent configurations.
+- [Superpowers](https://github.com/obra/superpowers) - Shell-based agentic skills methodology with composable capability configs.
 - [Trail of Bits Claude Code Config](https://github.com/trailofbits/claude-code-config) - Opinionated Claude Code defaults and workflows from a security-focused engineering team.
 
 ## Skill Engineering and Playbooks
 
 Hands-on resources for designing, testing, and shipping high-quality agent skills.
 
+- [Agent Skills for Context Engineering](https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering) - Collection of agent skills for context engineering, multi-agent architectures, and production systems.
+- [Agent Skills for LLMs (paper)](https://arxiv.org/abs/2602.12430) - Research on skill augmentation design principles and effectiveness for LLM-based agents.
 - [Anthropic: The Complete Guide to Building Skills for Claude (PDF)](https://resources.anthropic.com/hubfs/The-Complete-Guide-to-Building-Skill-for-Claude.pdf) - Canonical end-to-end guide covering structure, triggering, testing, and distribution.
 - [anthropics/skills](https://github.com/anthropics/skills) - Official production-ready skill examples and reference implementations.
 - [Claude Skill Engineering Playbook (this repo)](guides/claude-skill-engineering-playbook.md) - Distilled patterns, anti-patterns, templates, and troubleshooting from the Anthropic guide.
 - [Claude Skills Quickstart Checklist (this repo)](guides/claude-skills-quickstart-checklist.md) - Build-test-ship checklist for repeatable skill quality.
+- [SkillsBench](https://arxiv.org/html/2602.12670v1) - Benchmark for evaluating how well agent skills work across diverse tasks and harness configurations.
+- [Spring AI Agent Skills](https://spring.io/blog/2026/01/13/spring-ai-generic-agent-skills/) - Modular, reusable skill capabilities for the Spring AI Java ecosystem.
+- [Superpowers](https://github.com/obra/superpowers) - Agentic skills framework and software development methodology with composable skill architecture.
 
 ## Knowledge Graphs and Memory
 
@@ -406,7 +429,9 @@ Payment protocols and infrastructure for autonomous agent transactions.
 - [Google A2A x402 Extension](https://github.com/google-agentic-commerce/a2a-x402) - Cryptocurrency payments for the Agent-to-Agent protocol via x402.
 - [lobster.cash](https://www.lobster.cash) - Agent payment solution on Solana with Visa Intelligent Commerce integration by Crossmint.
 - [Request Network](https://request.network) - Crypto-native invoicing and payment request rails for agent billing workflows.
+- [Skyfire](https://www.skyfire.xyz) - Know Your Agent infrastructure for accountable autonomous commerce, backed by a16z.
 - [Solana Pay](https://solanapay.com) - Open payments standard for Solana-based checkout and transfer flows.
+- [Stripe Tempo](https://tempo.network) - Payments-focused blockchain with Machine Payments Protocol for AI agent autonomous transactions.
 - [Superfluid](https://superfluid.org) - Streaming payment primitives for machine-to-machine and agent subscriptions.
 - [x402 Foundation](https://www.x402.org) - Open protocol foundation governing the x402 payment standard.
 - [x402 Protocol](https://github.com/coinbase/x402) - Open HTTP payment protocol using the 402 status code for agent-to-service payments.
@@ -441,6 +466,7 @@ Quantitative finance frameworks and AI-driven trading systems.
 - [Freqtrade](https://github.com/freqtrade/freqtrade) - Open-source algorithmic trading bot in Python.
 - [Hummingbot](https://github.com/hummingbot/hummingbot) - Open-source market making and arbitrage bot.
 - [Lean](https://github.com/QuantConnect/Lean) - Algorithmic trading engine by QuantConnect.
+- [MiroFish](https://github.com/666ghj/MiroFish) - Multi-agent swarm intelligence engine for scenario simulation and market prediction workflows.
 - [NautilusTrader](https://github.com/nautechsystems/nautilus_trader) - High-performance algorithmic trading platform in Rust and Python.
 - [Phoenix v1](https://github.com/Ellipsis-Labs/phoenix-v1) - On-chain central limit order book protocol for low-latency execution agents.
 - [Qlib](https://github.com/microsoft/qlib) - AI-oriented quantitative investment platform from Microsoft.
@@ -472,7 +498,6 @@ Debugging, tracing, evaluation, and testing tools for AI agents.
 
 Curated papers on AI agents, multi-agent systems, and agent infrastructure.
 
-- [ArXiv Deep Research Map (this repo)](guides/arxiv-deep-research-map.md) - Category-by-category reading map spanning frameworks, coding, MCP/tool use, memory, security, multimodal, and quant/on-chain adjacent domains.
 - [A Survey on Large Language Model based Autonomous Agents](https://arxiv.org/abs/2308.11432) - Comprehensive survey of LLM-based agent architectures.
 - [ArXiv Deep Research Map (this repo)](guides/arxiv-deep-research-map.md) - Category-by-category reading map spanning frameworks, coding, MCP/tool use, memory, security, multimodal, and quant/on-chain adjacent domains.
 - [Awesome AI Agent Papers](https://github.com/VoltAgent/awesome-ai-agent-papers) - Continuously updated collection of agent research papers.
@@ -494,6 +519,7 @@ Forums, Discord servers, newsletters, and social accounts.
 - [ElizaOS Discord](https://discord.gg/elizaos) - Community for ElizaOS agent builders.
 - [LangChain Discord](https://discord.gg/langchain) - LangChain developer community.
 - [Latent Space Podcast](https://www.latent.space) - Podcast covering AI engineering and agents.
+- [Nous Research Discord](https://discord.gg/nousresearch) - Community for Hermes, OpenClaw, and Nous Research agent builders.
 - [r/artificial](https://www.reddit.com/r/artificial/) - Subreddit for AI discussions and news.
 - [r/LocalLLaMA](https://www.reddit.com/r/LocalLLaMA/) - Community for local LLM deployment and agent experimentation.
 - [Solana AI Discord](https://discord.gg/solana) - Solana developer community with AI channels.

--- a/README.md
+++ b/README.md
@@ -472,6 +472,7 @@ Debugging, tracing, evaluation, and testing tools for AI agents.
 
 Curated papers on AI agents, multi-agent systems, and agent infrastructure.
 
+- [ArXiv Deep Research Map (this repo)](guides/arxiv-deep-research-map.md) - Category-by-category reading map spanning frameworks, coding, MCP/tool use, memory, security, multimodal, and quant/on-chain adjacent domains.
 - [A Survey on Large Language Model based Autonomous Agents](https://arxiv.org/abs/2308.11432) - Comprehensive survey of LLM-based agent architectures.
 - [ArXiv Deep Research Map (this repo)](guides/arxiv-deep-research-map.md) - Category-by-category reading map spanning frameworks, coding, MCP/tool use, memory, security, multimodal, and quant/on-chain adjacent domains.
 - [Awesome AI Agent Papers](https://github.com/VoltAgent/awesome-ai-agent-papers) - Continuously updated collection of agent research papers.

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ CLI usage).
 - [Research Papers](#research-papers)
 - [Communities](#communities)
 
+<!-- RESOURCES:START -->
 ## Agent Frameworks
 
 Multi-agent orchestration, single-agent SDKs, and runtime frameworks.
@@ -315,21 +316,24 @@ Obsidian-specific architecture patterns and APIs for using vaults as agent memor
 
 Safety, red-teaming, and robustness tools for hardening agent behavior.
 
+- [DeepTeam](https://github.com/confident-ai/deepteam) - Framework for red-teaming LLMs and agent systems with automated attack generation and scoring.
 - [garak](https://github.com/NVIDIA/garak) - LLM vulnerability scanning and red-teaming toolkit for security testing.
 - [Guardrails AI](https://github.com/guardrails-ai/guardrails) - Validation and safety guardrails framework for LLM outputs.
 - [Invariant](https://github.com/invariantlabs-ai/invariant) - Guardrails framework for secure and robust agent development.
 - [JailbreakBench](https://github.com/JailbreakBench/jailbreakbench) - Open robustness benchmark for measuring jailbreak resistance in language models and agents.
 - [llm-attacks](https://github.com/llm-attacks/llm-attacks) - Reference implementation and resources for adversarial jailbreak attack evaluation.
 - [MCP Security Best Practices](https://modelcontextprotocol.io/docs/tutorials/security/security_best_practices) - Official security guidance for MCP authorization flows, threats, and mitigations.
+- [Microsoft Agent Governance Toolkit](https://github.com/microsoft/agent-governance-toolkit) - Policy enforcement and zero-trust governance toolkit for autonomous AI agent deployments.
 - [NeMo Guardrails](https://github.com/NVIDIA-NeMo/Guardrails) - Toolkit for adding programmable safety and policy guardrails to LLM systems.
 - [Promptfoo](https://github.com/promptfoo/promptfoo) - Red-teaming and robustness testing toolkit for LLM systems.
+
 - [PyRIT](https://github.com/Azure/PyRIT) - Python Risk Identification Tool for proactively testing generative AI security risks.
 - [Qualys TotalAI MCP Security](https://blog.qualys.com/product-tech/2026/03/19/mcp-servers-shadow-it-ai-qualys-totalai-2026) - MCP server security assessment and shadow IT detection for enterprise environments.
-
 ## Agent Configs and Dotfiles
 
 Configuration files and workflow examples for AI coding tools.
 
+- [AGENTS.md](https://github.com/agentsmd/agents.md) - Open format for repository-scoped instructions that guide coding agents across tools.
 - [awesome-cursorrules](https://github.com/PatrickJS/awesome-cursorrules) - Curated list of Cursor rule files.
 - [Claude Code Memory Files](https://docs.anthropic.com/en/docs/claude-code/memory) - Guide to CLAUDE.md and project memory.
 - [Claude Code Starter Configs](claude/) - Ready-to-use CLAUDE.md, rules, hooks, and skills for Claude Code projects.
@@ -337,23 +341,27 @@ Configuration files and workflow examples for AI coding tools.
 - [Cursor Starter Configs](cursorrules/) - Ready-to-use .cursorrules and rule files for Cursor projects.
 - [CursorDirectory](https://cursor.directory) - Community-shared Cursor rules and configurations.
 - [dotfiles](https://dotfiles.github.io) - Guide to managing dotfiles including agent configurations.
+- [Ruler](https://github.com/intellectronica/ruler) - Policy layer for applying consistent coding rules across different AI coding agents.
+
 - [Superpowers](https://github.com/obra/superpowers) - Shell-based agentic skills methodology with composable capability configs.
 - [Trail of Bits Claude Code Config](https://github.com/trailofbits/claude-code-config) - Opinionated Claude Code defaults and workflows from a security-focused engineering team.
-
 ## Skill Engineering and Playbooks
 
 Hands-on resources for designing, testing, and shipping high-quality agent skills.
 
 - [Agent Skills for Context Engineering](https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering) - Collection of agent skills for context engineering, multi-agent architectures, and production systems.
 - [Agent Skills for LLMs (paper)](https://arxiv.org/abs/2602.12430) - Research on skill augmentation design principles and effectiveness for LLM-based agents.
+- [AgentSkills Specification](https://github.com/agentskills/agentskills) - Open specification and documentation for portable agent skill packaging and execution semantics.
 - [Anthropic: The Complete Guide to Building Skills for Claude (PDF)](https://resources.anthropic.com/hubfs/The-Complete-Guide-to-Building-Skill-for-Claude.pdf) - Canonical end-to-end guide covering structure, triggering, testing, and distribution.
 - [anthropics/skills](https://github.com/anthropics/skills) - Official production-ready skill examples and reference implementations.
 - [Claude Skill Engineering Playbook (this repo)](guides/claude-skill-engineering-playbook.md) - Distilled patterns, anti-patterns, templates, and troubleshooting from the Anthropic guide.
 - [Claude Skills Quickstart Checklist (this repo)](guides/claude-skills-quickstart-checklist.md) - Build-test-ship checklist for repeatable skill quality.
+- [OpenAI Skills](https://github.com/openai/skills) - Official Codex skills catalog with reusable workflows and integrations.
 - [SkillsBench](https://arxiv.org/html/2602.12670v1) - Benchmark for evaluating how well agent skills work across diverse tasks and harness configurations.
+
 - [Spring AI Agent Skills](https://spring.io/blog/2026/01/13/spring-ai-generic-agent-skills/) - Modular, reusable skill capabilities for the Spring AI Java ecosystem.
 - [Superpowers](https://github.com/obra/superpowers) - Agentic skills framework and software development methodology with composable skill architecture.
-
+- [Vercel Agent Skills](https://github.com/vercel-labs/agent-skills) - Official production skill collection for building and sharing reusable agent capabilities.
 ## Knowledge Graphs and Memory
 
 Agent memory architectures, knowledge graphs, and second-brain integrations.
@@ -484,6 +492,7 @@ Debugging, tracing, evaluation, and testing tools for AI agents.
 - [Helicone](https://github.com/Helicone/helicone) - Open-source LLM observability and monitoring platform.
 - [LangFuse](https://github.com/langfuse/langfuse) - Open-source LLM engineering platform for tracing and evaluation.
 - [LangSmith](https://smith.langchain.com) - Platform for debugging, testing, and monitoring LLM applications.
+- [LangWatch](https://github.com/langwatch/langwatch) - Open platform for LLM evaluations and agent testing with trace-centric diagnostics.
 - [LiteLLM](https://github.com/BerriAI/litellm) - LLM gateway and proxy with logging, cost tracking, and routing controls.
 - [OpenAI Evals](https://github.com/openai/evals) - Framework and benchmark registry for evaluating LLM systems.
 - [OpenLLMetry](https://github.com/traceloop/openllmetry) - OpenTelemetry-based observability for LLM applications.
@@ -492,11 +501,12 @@ Debugging, tracing, evaluation, and testing tools for AI agents.
 - [Portkey](https://github.com/Portkey-AI/gateway) - AI gateway with observability, caching, and fallback routing.
 - [SigNoz](https://github.com/SigNoz/signoz) - OpenTelemetry-native observability platform for traces, logs, and metrics.
 - [TruLens](https://github.com/truera/trulens) - Open-source framework for evaluating and tracking LLM and agent experiments.
-- [Weave](https://github.com/wandb/weave) - Toolkit for tracking and evaluating LLM applications from W&B.
 
+- [Weave](https://github.com/wandb/weave) - Toolkit for tracking and evaluating LLM applications from W&B.
 ## Research Papers
 
 Curated papers on AI agents, multi-agent systems, and agent infrastructure.
+
 
 - [A Survey on Large Language Model based Autonomous Agents](https://arxiv.org/abs/2308.11432) - Comprehensive survey of LLM-based agent architectures.
 - [ArXiv Deep Research Map (this repo)](guides/arxiv-deep-research-map.md) - Category-by-category reading map spanning frameworks, coding, MCP/tool use, memory, security, multimodal, and quant/on-chain adjacent domains.
@@ -524,6 +534,7 @@ Forums, Discord servers, newsletters, and social accounts.
 - [r/LocalLLaMA](https://www.reddit.com/r/LocalLLaMA/) - Community for local LLM deployment and agent experimentation.
 - [Solana AI Discord](https://discord.gg/solana) - Solana developer community with AI channels.
 
+<!-- RESOURCES:END -->
 ---
 
 ## Contributing

--- a/data/resources.json
+++ b/data/resources.json
@@ -1,0 +1,2713 @@
+{
+  "schema_version": "1.0.0",
+  "generated_from": "README.md",
+  "managed_block": {
+    "start_marker": "<!-- RESOURCES:START -->",
+    "end_marker": "<!-- RESOURCES:END -->"
+  },
+  "sections": [
+    {
+      "name": "Agent Frameworks",
+      "items": [
+        {
+          "type": "text",
+          "text": ""
+        },
+        {
+          "type": "text",
+          "text": "Multi-agent orchestration, single-agent SDKs, and runtime frameworks."
+        },
+        {
+          "type": "text",
+          "text": ""
+        },
+        {
+          "type": "entry",
+          "name": "AG2",
+          "url": "https://github.com/ag2ai/ag2",
+          "description": "Open-source AgentOS for building multi-agent systems (evolved from AutoGen)."
+        },
+        {
+          "type": "entry",
+          "name": "Agno",
+          "url": "https://github.com/agno-agi/agno",
+          "description": "Framework for building and running agentic software at scale."
+        },
+        {
+          "type": "entry",
+          "name": "AutoGen",
+          "url": "https://github.com/microsoft/autogen",
+          "description": "Multi-agent conversation framework from Microsoft Research."
+        },
+        {
+          "type": "entry",
+          "name": "Claude Agent SDK",
+          "url": "https://github.com/anthropics/anthropic-sdk-python",
+          "description": "Official Python SDK for building agents with Claude models."
+        },
+        {
+          "type": "entry",
+          "name": "CrewAI",
+          "url": "https://github.com/crewAIInc/crewAI",
+          "description": "Role-based multi-agent orchestration framework."
+        },
+        {
+          "type": "entry",
+          "name": "ElizaOS",
+          "url": "https://github.com/elizaOS/eliza",
+          "description": "Multi-agent simulation framework for autonomous characters."
+        },
+        {
+          "type": "entry",
+          "name": "Google A2A",
+          "url": "https://github.com/google/A2A",
+          "description": "Agent-to-Agent protocol for cross-framework agent communication."
+        },
+        {
+          "type": "entry",
+          "name": "Google ADK",
+          "url": "https://github.com/google/adk-python",
+          "description": "Agent Development Kit for building agents with Gemini."
+        },
+        {
+          "type": "entry",
+          "name": "Haystack",
+          "url": "https://github.com/deepset-ai/haystack",
+          "description": "LLM orchestration framework for building search and RAG pipelines."
+        },
+        {
+          "type": "entry",
+          "name": "Hermes Agent",
+          "url": "https://github.com/NousResearch/hermes-agent",
+          "description": "Tool-using autonomous agent platform with memory, skills, delegation, and MCP support."
+        },
+        {
+          "type": "entry",
+          "name": "Julep",
+          "url": "https://github.com/julep-ai/julep",
+          "description": "Stateful agent platform with built-in persistence and task workflows."
+        },
+        {
+          "type": "entry",
+          "name": "LangChain",
+          "url": "https://github.com/langchain-ai/langchain",
+          "description": "Composable framework for building LLM-powered applications."
+        },
+        {
+          "type": "entry",
+          "name": "LangGraph",
+          "url": "https://github.com/langchain-ai/langgraph",
+          "description": "Library for building stateful multi-agent workflows as graphs."
+        },
+        {
+          "type": "entry",
+          "name": "Letta",
+          "url": "https://github.com/letta-ai/letta",
+          "description": "Stateful agents with long-term memory (formerly MemGPT)."
+        },
+        {
+          "type": "entry",
+          "name": "LlamaIndex",
+          "url": "https://github.com/run-llama/llama_index",
+          "description": "Data framework for document agents, retrieval, and workflow orchestration."
+        },
+        {
+          "type": "entry",
+          "name": "Magentic-One",
+          "url": "https://github.com/microsoft/autogen/tree/main/python/packages/autogen-magentic-one",
+          "description": "Multi-agent team for complex web and file tasks."
+        },
+        {
+          "type": "entry",
+          "name": "Mastra",
+          "url": "https://github.com/mastra-ai/mastra",
+          "description": "TypeScript framework for building AI applications and agents."
+        },
+        {
+          "type": "entry",
+          "name": "Microsoft Agent Framework",
+          "url": "https://github.com/microsoft/agent-framework",
+          "description": "Framework for building, orchestrating, and deploying agents with Python and .NET support."
+        },
+        {
+          "type": "entry",
+          "name": "NemoClaw",
+          "url": "https://github.com/NVIDIA/NemoClaw",
+          "description": "NVIDIA plugin stack for secure installation and operation of OpenClaw agents."
+        },
+        {
+          "type": "entry",
+          "name": "OpenAI Agents SDK",
+          "url": "https://github.com/openai/openai-agents-python",
+          "description": "Official SDK for building agents with OpenAI models."
+        },
+        {
+          "type": "entry",
+          "name": "OpenClaw",
+          "url": "https://github.com/openclaw/openclaw",
+          "description": "Self-hosted personal AI agent with multi-platform messaging and skill registry."
+        },
+        {
+          "type": "entry",
+          "name": "Phidata",
+          "url": "https://github.com/phidatahq/phidata",
+          "description": "Toolkit for building AI assistants with memory and tools."
+        },
+        {
+          "type": "entry",
+          "name": "PydanticAI",
+          "url": "https://github.com/pydantic/pydantic-ai",
+          "description": "Type-safe agent framework built around Pydantic."
+        },
+        {
+          "type": "entry",
+          "name": "Rig",
+          "url": "https://github.com/0xPlaygrounds/rig",
+          "description": "Rust framework for building LLM-powered applications."
+        },
+        {
+          "type": "entry",
+          "name": "Semantic Kernel",
+          "url": "https://github.com/microsoft/semantic-kernel",
+          "description": "SDK for integrating LLMs into apps with plugin architecture."
+        },
+        {
+          "type": "entry",
+          "name": "Smolagents",
+          "url": "https://github.com/huggingface/smolagents",
+          "description": "Lightweight agent framework from Hugging Face."
+        },
+        {
+          "type": "entry",
+          "name": "Swarm",
+          "url": "https://github.com/openai/swarm",
+          "description": "Educational framework for multi-agent handoffs and routines."
+        },
+        {
+          "type": "text",
+          "text": ""
+        }
+      ]
+    },
+    {
+      "name": "Coding Agents",
+      "items": [
+        {
+          "type": "text",
+          "text": ""
+        },
+        {
+          "type": "text",
+          "text": "AI agents that write, review, and debug code."
+        },
+        {
+          "type": "text",
+          "text": ""
+        },
+        {
+          "type": "entry",
+          "name": "Aider",
+          "url": "https://github.com/Aider-AI/aider",
+          "description": "AI pair programming in the terminal with git integration."
+        },
+        {
+          "type": "entry",
+          "name": "Claude Code",
+          "url": "https://docs.anthropic.com/en/docs/claude-code",
+          "description": "Anthropic's agentic CLI for code generation and editing."
+        },
+        {
+          "type": "entry",
+          "name": "Cline",
+          "url": "https://github.com/cline/cline",
+          "description": "Autonomous coding agent for VS Code with tool use."
+        },
+        {
+          "type": "entry",
+          "name": "Continue",
+          "url": "https://github.com/continuedev/continue",
+          "description": "Open-source AI code assistant for VS Code and JetBrains."
+        },
+        {
+          "type": "entry",
+          "name": "Cursor",
+          "url": "https://cursor.com",
+          "description": "AI-first code editor built on VS Code."
+        },
+        {
+          "type": "entry",
+          "name": "Devin",
+          "url": "https://devin.ai",
+          "description": "Autonomous software engineering agent by Cognition."
+        },
+        {
+          "type": "entry",
+          "name": "Goose",
+          "url": "https://github.com/block/goose",
+          "description": "Autonomous developer agent from Block."
+        },
+        {
+          "type": "entry",
+          "name": "Leanstral",
+          "url": "https://mistral.ai/news/leanstral",
+          "description": "Open-source code agent for Lean 4 formal verification from Mistral AI."
+        },
+        {
+          "type": "entry",
+          "name": "Open-SWE",
+          "url": "https://github.com/langchain-ai/open-swe",
+          "description": "Open-source asynchronous coding agent from LangChain for software engineering tasks."
+        },
+        {
+          "type": "entry",
+          "name": "OpenCodex",
+          "url": "https://github.com/openai/codex",
+          "description": "OpenAI's CLI coding agent."
+        },
+        {
+          "type": "entry",
+          "name": "OpenHands",
+          "url": "https://github.com/All-Hands-AI/OpenHands",
+          "description": "Platform for AI software development agents (formerly OpenDevin)."
+        },
+        {
+          "type": "entry",
+          "name": "SERA",
+          "url": "https://allenai.org/blog/open-coding-agents",
+          "description": "Open 14B-parameter coding agent from Ai2 that adapts to private codebases."
+        },
+        {
+          "type": "entry",
+          "name": "SWE-Agent",
+          "url": "https://github.com/princeton-nlp/SWE-agent",
+          "description": "Agent for automatically resolving GitHub issues."
+        },
+        {
+          "type": "entry",
+          "name": "Windsurf",
+          "url": "https://codeium.com/windsurf",
+          "description": "AI-native IDE by Codeium with agentic flows."
+        },
+        {
+          "type": "text",
+          "text": ""
+        },
+        {
+          "type": "text",
+          "text": "### Claude Code Resources"
+        },
+        {
+          "type": "text",
+          "text": ""
+        },
+        {
+          "type": "entry",
+          "name": "awesome-claude-code",
+          "url": "https://github.com/hesreallyhim/awesome-claude-code",
+          "description": "Curated list of Claude Code resources."
+        },
+        {
+          "type": "entry",
+          "name": "Claude Code Hooks",
+          "url": "https://docs.anthropic.com/en/docs/claude-code/hooks",
+          "description": "Event-driven shell command automation."
+        },
+        {
+          "type": "entry",
+          "name": "Claude Code Skills",
+          "url": "https://docs.anthropic.com/en/docs/claude-code/memory#slash-commands-as-custom-skills",
+          "description": "Reusable prompt-driven workflows."
+        },
+        {
+          "type": "entry",
+          "name": "CLAUDE.md Guide",
+          "url": "https://docs.anthropic.com/en/docs/claude-code/memory",
+          "description": "Official documentation on memory files."
+        },
+        {
+          "type": "entry",
+          "name": "claude-code-tips",
+          "url": "https://github.com/ykdojo/claude-code-tips",
+          "description": "Community-sourced tips and tricks."
+        },
+        {
+          "type": "entry",
+          "name": "Everything Claude Code",
+          "url": "https://github.com/affaan-m/everything-claude-code",
+          "description": "Comprehensive Claude Code harness with agent skills, hooks, and multi-language support."
+        },
+        {
+          "type": "text",
+          "text": ""
+        },
+        {
+          "type": "text",
+          "text": "### Codex Resources"
+        },
+        {
+          "type": "text",
+          "text": ""
+        },
+        {
+          "type": "entry",
+          "name": "Codex Docs",
+          "url": "https://developers.openai.com/codex",
+          "description": "Official Codex documentation hub."
+        },
+        {
+          "type": "entry",
+          "name": "Codex CLI",
+          "url": "https://developers.openai.com/codex/cli",
+          "description": "Guide to local Codex CLI workflows."
+        },
+        {
+          "type": "entry",
+          "name": "Codex Non-Interactive Mode",
+          "url": "https://developers.openai.com/codex/noninteractive",
+          "description": "Batch and CI automation with `codex exec`."
+        },
+        {
+          "type": "entry",
+          "name": "AGENTS.md Guide (Codex)",
+          "url": "https://developers.openai.com/codex/guides/agents-md",
+          "description": "Instruction hierarchy and scoping patterns for Codex."
+        },
+        {
+          "type": "entry",
+          "name": "Codex Optimization Playbook (this repo)",
+          "url": "guides/codex-optimization-playbook.md",
+          "description": "Practical operator patterns for speed, safety, and quality."
+        },
+        {
+          "type": "text",
+          "text": ""
+        }
+      ]
+    },
+    {
+      "name": "Voice and Multimodal Agents",
+      "items": [
+        {
+          "type": "text",
+          "text": ""
+        },
+        {
+          "type": "text",
+          "text": "Agents with voice, vision, and multimodal capabilities."
+        },
+        {
+          "type": "text",
+          "text": ""
+        },
+        {
+          "type": "entry",
+          "name": "ElevenLabs",
+          "url": "https://github.com/elevenlabs/elevenlabs-python",
+          "description": "Text-to-speech and voice cloning API for agent voice interfaces."
+        },
+        {
+          "type": "entry",
+          "name": "LiveKit Agents",
+          "url": "https://github.com/livekit/agents",
+          "description": "Framework for building real-time multimodal AI agents."
+        },
+        {
+          "type": "entry",
+          "name": "Pipecat",
+          "url": "https://github.com/pipecat-ai/pipecat",
+          "description": "Framework for building voice and multimodal conversational agents."
+        },
+        {
+          "type": "entry",
+          "name": "Sesame CSM",
+          "url": "https://github.com/SesameAILabs/csm",
+          "description": "Conversational speech model for real-time voice agent interactions."
+        },
+        {
+          "type": "entry",
+          "name": "TEN Framework",
+          "url": "https://github.com/TEN-framework/ten-framework",
+          "description": "Open-source framework for conversational voice AI agents."
+        },
+        {
+          "type": "entry",
+          "name": "Ultravox",
+          "url": "https://github.com/fixie-ai/ultravox",
+          "description": "Fast multimodal LLM for real-time voice AI."
+        },
+        {
+          "type": "entry",
+          "name": "Vapi",
+          "url": "https://vapi.ai",
+          "description": "Platform for building and deploying voice AI agents."
+        },
+        {
+          "type": "entry",
+          "name": "Vocode Core",
+          "url": "https://github.com/vocodedev/vocode-core",
+          "description": "Modular open-source framework for building voice-based LLM agents."
+        },
+        {
+          "type": "entry",
+          "name": "Whisper",
+          "url": "https://github.com/openai/whisper",
+          "description": "Open-source speech recognition model from OpenAI."
+        },
+        {
+          "type": "text",
+          "text": ""
+        }
+      ]
+    },
+    {
+      "name": "Hermes Stack",
+      "items": [
+        {
+          "type": "text",
+          "text": ""
+        },
+        {
+          "type": "text",
+          "text": "Hermes Agent runtime, deployment rails, and operator resources."
+        },
+        {
+          "type": "text",
+          "text": ""
+        },
+        {
+          "type": "entry",
+          "name": "Hermes Agent",
+          "url": "https://github.com/NousResearch/hermes-agent",
+          "description": "Open-source autonomous AI agent with CLI, gateway, memory, subagents, and broad tool integrations."
+        },
+        {
+          "type": "entry",
+          "name": "Hermes Hub (this repo)",
+          "url": "hermes/README.md",
+          "description": "Local operator knowledge base for Hermes setup, configuration, memory/skills workflows, and contribution orientation."
+        },
+        {
+          "type": "entry",
+          "name": "Hermes Agent + hermes-fly Best Practices (this repo)",
+          "url": "guides/hermes-agent-hermes-fly-playbook.md",
+          "description": "Practical setup, operations, security, and optimization playbook."
+        },
+        {
+          "type": "entry",
+          "name": "Hermes Agent Optimization Playbook (this repo)",
+          "url": "guides/hermes-agent-optimization-playbook.md",
+          "description": "Deep operator guide for context, delegation, memory, and execution tuning."
+        },
+        {
+          "type": "entry",
+          "name": "Hermes Agent Self-Evolution",
+          "url": "https://github.com/NousResearch/hermes-agent-self-evolution",
+          "description": "Evolutionary self-improvement framework for optimizing Hermes Agent prompts, skills, and code."
+        },
+        {
+          "type": "entry",
+          "name": "Hermes Paperclip Adapter",
+          "url": "https://github.com/NousResearch/hermes-paperclip-adapter",
+          "description": "Adapter for running Hermes Agent as a managed employee inside Paperclip."
+        },
+        {
+          "type": "entry",
+          "name": "hermes-fly",
+          "url": "https://github.com/alexfazio/hermes-fly",
+          "description": "Fly.io deployment and operations CLI for Hermes Agent with deploy, logs, doctor, and teardown workflows."
+        },
+        {
+          "type": "entry",
+          "name": "Hermes Stack Maturity Ladder (this repo)",
+          "url": "guides/hermes-stack-maturity-ladder.md",
+          "description": "L1-L3 readiness model with upgrade paths and operational checklist."
+        },
+        {
+          "type": "entry",
+          "name": "Hermes Stack Quickstart Recipes (this repo)",
+          "url": "guides/hermes-stack-quickstart-recipes.md",
+          "description": "Copy/paste recipes for local dev, hosted production, secure mode, and CI operations."
+        },
+        {
+          "type": "text",
+          "text": ""
+        }
+      ]
+    },
+    {
+      "name": "CLI and TUI Tools",
+      "items": [
+        {
+          "type": "text",
+          "text": ""
+        },
+        {
+          "type": "text",
+          "text": "Terminal-based agent interfaces and developer tools."
+        },
+        {
+          "type": "text",
+          "text": ""
+        },
+        {
+          "type": "entry",
+          "name": "Claude Code",
+          "url": "https://docs.anthropic.com/en/docs/claude-code",
+          "description": "Agentic CLI that operates directly in the terminal."
+        },
+        {
+          "type": "entry",
+          "name": "Claude Squad",
+          "url": "https://github.com/smtg-ai/claude-squad",
+          "description": "tmux-based harness for running and managing multiple Claude Code sessions side-by-side."
+        },
+        {
+          "type": "entry",
+          "name": "cmux",
+          "url": "https://github.com/manaflow-ai/cmux",
+          "description": "Ghostty-based macOS terminal with vertical tabs and notifications for AI coding agents."
+        },
+        {
+          "type": "entry",
+          "name": "Crush",
+          "url": "https://github.com/charmbracelet/crush",
+          "description": "Agentic coding TUI from Charmbracelet with multi-provider support and LSP awareness."
+        },
+        {
+          "type": "entry",
+          "name": "dmux",
+          "url": "https://github.com/standardagents/dmux",
+          "description": "Dev agent multiplexer for managing coding agents across git worktrees."
+        },
+        {
+          "type": "entry",
+          "name": "Gemini CLI",
+          "url": "https://github.com/google-gemini/gemini-cli",
+          "description": "Google's command-line interface for Gemini models."
+        },
+        {
+          "type": "entry",
+          "name": "Glow",
+          "url": "https://github.com/charmbracelet/glow",
+          "description": "Terminal Markdown renderer useful for agent output."
+        },
+        {
+          "type": "entry",
+          "name": "Hermes Agent",
+          "url": "https://github.com/NousResearch/hermes-agent",
+          "description": "CLI and gateway agent runtime with tools, memory, delegation, and automation support."
+        },
+        {
+          "type": "entry",
+          "name": "hermes-fly",
+          "url": "https://github.com/alexfazio/hermes-fly",
+          "description": "CLI wizard to deploy and operate Hermes Agent on Fly.io."
+        },
+        {
+          "type": "entry",
+          "name": "lazygit",
+          "url": "https://github.com/jesseduffield/lazygit",
+          "description": "Terminal UI for git commonly paired with coding agents."
+        },
+        {
+          "type": "entry",
+          "name": "llm",
+          "url": "https://github.com/simonw/llm",
+          "description": "CLI tool for interacting with LLMs from the terminal."
+        },
+        {
+          "type": "entry",
+          "name": "aichat",
+          "url": "https://github.com/sigoden/aichat",
+          "description": "All-in-one LLM CLI with chat, shell assistant, RAG, and agent features."
+        },
+        {
+          "type": "entry",
+          "name": "OpenCode",
+          "url": "https://github.com/opencode-ai/opencode",
+          "description": "Open-source terminal coding agent with multi-provider support and LSP integration."
+        },
+        {
+          "type": "entry",
+          "name": "OpenCodex",
+          "url": "https://github.com/openai/codex",
+          "description": "Lightweight CLI coding agent from OpenAI."
+        },
+        {
+          "type": "entry",
+          "name": "Plandex",
+          "url": "https://github.com/plandex-ai/plandex",
+          "description": "Plan-first CLI agent for multi-file features with structured steps and large context."
+        },
+        {
+          "type": "entry",
+          "name": "sgpt",
+          "url": "https://github.com/tbckr/sgpt",
+          "description": "Command-line productivity tool powered by LLMs."
+        },
+        {
+          "type": "entry",
+          "name": "tmux",
+          "url": "https://github.com/tmux/tmux",
+          "description": "Terminal multiplexer for running agents in persistent sessions."
+        },
+        {
+          "type": "entry",
+          "name": "Warp",
+          "url": "https://www.warp.dev",
+          "description": "Modern terminal with built-in AI assistance."
+        },
+        {
+          "type": "entry",
+          "name": "Zellij",
+          "url": "https://github.com/zellij-org/zellij",
+          "description": "Terminal workspace with plugin system for agent integration."
+        },
+        {
+          "type": "text",
+          "text": ""
+        }
+      ]
+    },
+    {
+      "name": "Agent Runtime Infrastructure",
+      "items": [
+        {
+          "type": "text",
+          "text": ""
+        },
+        {
+          "type": "text",
+          "text": "Execution sandboxes and runtime platforms for safely running agent actions and generated code."
+        },
+        {
+          "type": "text",
+          "text": ""
+        },
+        {
+          "type": "entry",
+          "name": "CUA",
+          "url": "https://github.com/trycua/cua",
+          "description": "Open-source infrastructure for computer-use agents with sandboxes, SDKs, and benchmarks."
+        },
+        {
+          "type": "entry",
+          "name": "Daytona",
+          "url": "https://github.com/daytonaio/daytona",
+          "description": "Secure and elastic runtime infrastructure for AI-generated code execution."
+        },
+        {
+          "type": "entry",
+          "name": "E2B",
+          "url": "https://github.com/e2b-dev/E2B",
+          "description": "Open-source secure cloud sandbox environment for AI agents."
+        },
+        {
+          "type": "entry",
+          "name": "Firecracker",
+          "url": "https://github.com/firecracker-microvm/firecracker",
+          "description": "Secure and fast microVM technology for isolated agent execution."
+        },
+        {
+          "type": "entry",
+          "name": "gVisor",
+          "url": "https://github.com/google/gvisor",
+          "description": "Application kernel for containers that adds a strong isolation boundary."
+        },
+        {
+          "type": "entry",
+          "name": "Kata Containers",
+          "url": "https://github.com/kata-containers/kata-containers",
+          "description": "Lightweight VM-based container runtime for stronger workload isolation."
+        },
+        {
+          "type": "entry",
+          "name": "Modal",
+          "url": "https://modal.com",
+          "description": "Serverless compute platform often used for running agent workloads and tools."
+        },
+        {
+          "type": "entry",
+          "name": "Morph",
+          "url": "https://morphcloud.com",
+          "description": "Cloud sandbox runtime for AI agents with snapshot/restore and time-travel debugging."
+        },
+        {
+          "type": "entry",
+          "name": "RunPod Python SDK",
+          "url": "https://github.com/runpod/runpod-python",
+          "description": "Python SDK for RunPod serverless and worker-based AI workloads."
+        },
+        {
+          "type": "text",
+          "text": ""
+        }
+      ]
+    },
+    {
+      "name": "MCP Ecosystem",
+      "items": [
+        {
+          "type": "text",
+          "text": ""
+        },
+        {
+          "type": "text",
+          "text": "Model Context Protocol servers, clients, and tooling."
+        },
+        {
+          "type": "text",
+          "text": ""
+        },
+        {
+          "type": "entry",
+          "name": "Awesome MCP Servers",
+          "url": "https://github.com/punkpeye/awesome-mcp-servers",
+          "description": "Curated list of MCP server implementations."
+        },
+        {
+          "type": "entry",
+          "name": "Chrome DevTools MCP",
+          "url": "https://github.com/ChromeDevTools/chrome-devtools-mcp",
+          "description": "Official Chrome DevTools MCP server for coding and browser automation agents."
+        },
+        {
+          "type": "entry",
+          "name": "Context7 MCP",
+          "url": "https://github.com/upstash/context7",
+          "description": "Most-used MCP server in 2026; provides up-to-date library documentation to agents."
+        },
+        {
+          "type": "entry",
+          "name": "FastMCP",
+          "url": "https://github.com/PrefectHQ/fastmcp",
+          "description": "Pythonic framework for building MCP servers and clients quickly."
+        },
+        {
+          "type": "entry",
+          "name": "GitHub MCP Server",
+          "url": "https://github.com/github/github-mcp-server",
+          "description": "Official MCP server for GitHub workflows and repository actions."
+        },
+        {
+          "type": "entry",
+          "name": "mcp",
+          "url": "https://github.com/modelcontextprotocol/servers",
+          "description": "Official reference MCP server implementations."
+        },
+        {
+          "type": "entry",
+          "name": "MCP Agent",
+          "url": "https://github.com/lastmile-ai/mcp-agent",
+          "description": "Framework patterns for building agents on top of MCP."
+        },
+        {
+          "type": "entry",
+          "name": "MCP for Beginners",
+          "url": "https://github.com/microsoft/mcp-for-beginners",
+          "description": "Cross-language curriculum and practical examples for learning MCP."
+        },
+        {
+          "type": "entry",
+          "name": "MCP Go SDK",
+          "url": "https://github.com/mark3labs/mcp-go",
+          "description": "Go implementation of the Model Context Protocol."
+        },
+        {
+          "type": "entry",
+          "name": "MCP Inspector",
+          "url": "https://github.com/modelcontextprotocol/inspector",
+          "description": "Official inspector and debugging tool for MCP servers."
+        },
+        {
+          "type": "entry",
+          "name": "MCP Python SDK",
+          "url": "https://github.com/modelcontextprotocol/python-sdk",
+          "description": "Official Python SDK for building MCP servers."
+        },
+        {
+          "type": "entry",
+          "name": "MCP Registry",
+          "url": "https://github.com/modelcontextprotocol/registry",
+          "description": "Community registry service for discovering MCP servers."
+        },
+        {
+          "type": "entry",
+          "name": "MCP Roadmap 2026",
+          "url": "https://blog.modelcontextprotocol.io/posts/2026-mcp-roadmap/",
+          "description": "Official 2026 roadmap covering remote-first servers, discoverability, and enterprise auth."
+        },
+        {
+          "type": "entry",
+          "name": "MCP Rust SDK",
+          "url": "https://github.com/modelcontextprotocol/rust-sdk",
+          "description": "Official Rust SDK for building MCP servers."
+        },
+        {
+          "type": "entry",
+          "name": "MCP Spec",
+          "url": "https://modelcontextprotocol.io/specification",
+          "description": "Official Model Context Protocol specification."
+        },
+        {
+          "type": "entry",
+          "name": "MCP Specification Repo",
+          "url": "https://github.com/modelcontextprotocol/modelcontextprotocol",
+          "description": "Canonical specification and documentation repository."
+        },
+        {
+          "type": "entry",
+          "name": "MCP TypeScript SDK",
+          "url": "https://github.com/modelcontextprotocol/typescript-sdk",
+          "description": "Official TypeScript SDK for building MCP servers."
+        },
+        {
+          "type": "entry",
+          "name": "Playwright MCP",
+          "url": "https://github.com/microsoft/playwright-mcp",
+          "description": "MCP server for browser automation via Playwright."
+        },
+        {
+          "type": "entry",
+          "name": "Smithery",
+          "url": "https://smithery.ai",
+          "description": "Registry and hosting platform for MCP servers."
+        },
+        {
+          "type": "text",
+          "text": ""
+        }
+      ]
+    },
+    {
+      "name": "Prompt Engineering",
+      "items": [
+        {
+          "type": "text",
+          "text": ""
+        },
+        {
+          "type": "text",
+          "text": "Instruction-writing craft: system prompts, response framing, and reusable prompt templates."
+        },
+        {
+          "type": "text",
+          "text": "Focus here on *what to ask and how to phrase it* at the prompt layer."
+        },
+        {
+          "type": "text",
+          "text": ""
+        },
+        {
+          "type": "entry",
+          "name": "Anthropic: 2026 Agentic Coding Trends Report (PDF)",
+          "url": "https://resources.anthropic.com/hubfs/2026%20Agentic%20Coding%20Trends%20Report.pdf",
+          "description": "Data-driven analysis of how coding agents reshape software development."
+        },
+        {
+          "type": "entry",
+          "name": "Anthropic Prompt Library",
+          "url": "https://docs.anthropic.com/en/prompt-library",
+          "description": "Official prompt examples from Anthropic."
+        },
+        {
+          "type": "entry",
+          "name": "awesome-chatgpt-prompts",
+          "url": "https://github.com/f/awesome-chatgpt-prompts",
+          "description": "Collection of prompt examples for ChatGPT."
+        },
+        {
+          "type": "entry",
+          "name": "Claude System Prompts",
+          "url": "https://docs.anthropic.com/en/docs/build-with-claude/prompt-engineering",
+          "description": "Guide to writing effective system prompts."
+        },
+        {
+          "type": "entry",
+          "name": "DSPy",
+          "url": "https://github.com/stanfordnlp/dspy",
+          "description": "Framework for programming with foundation models instead of prompting."
+        },
+        {
+          "type": "entry",
+          "name": "fabric",
+          "url": "https://github.com/danielmiessler/fabric",
+          "description": "Framework for augmenting humans using AI with curated prompts."
+        },
+        {
+          "type": "entry",
+          "name": "LangChain Hub",
+          "url": "https://smith.langchain.com/hub",
+          "description": "Community-driven prompt and chain sharing platform."
+        },
+        {
+          "type": "entry",
+          "name": "OpenAI Prompt Engineering Guide",
+          "url": "https://platform.openai.com/docs/guides/prompt-engineering",
+          "description": "Official guide to designing reliable prompts and instruction patterns."
+        },
+        {
+          "type": "entry",
+          "name": "Promptfoo",
+          "url": "https://github.com/promptfoo/promptfoo",
+          "description": "Testing and evaluation framework for LLM prompts."
+        },
+        {
+          "type": "entry",
+          "name": "System Prompts",
+          "url": "https://github.com/mustvlad/ChatGPT-System-Prompts",
+          "description": "Collection of system prompts for various AI models."
+        },
+        {
+          "type": "text",
+          "text": ""
+        }
+      ]
+    },
+    {
+      "name": "Agent Harnessing and Evaluation",
+      "items": [
+        {
+          "type": "text",
+          "text": ""
+        },
+        {
+          "type": "text",
+          "text": "Harnesses, benchmarks, and evaluation frameworks for measuring agent quality and reliability."
+        },
+        {
+          "type": "text",
+          "text": ""
+        },
+        {
+          "type": "text",
+          "text": "### Benchmark Reality Check (real-world tool use)"
+        },
+        {
+          "type": "text",
+          "text": ""
+        },
+        {
+          "type": "entry",
+          "name": "MCPMark (paper)",
+          "url": "https://arxiv.org/abs/2509.24002",
+          "description": "127-task MCP benchmark; reports best pass@1 at 52.56% (gpt-5-medium), with several strong models below 30% pass@1."
+        },
+        {
+          "type": "entry",
+          "name": "MCPMark (leaderboard)",
+          "url": "https://mcpmark.ai/",
+          "description": "Live model comparisons for realistic MCP task execution."
+        },
+        {
+          "type": "entry",
+          "name": "τ-bench",
+          "url": "https://arxiv.org/abs/2406.12045",
+          "description": "Tool-agent-user benchmark; reports strong function-calling agents still below 50% task success in its setup."
+        },
+        {
+          "type": "entry",
+          "name": "OSWorld",
+          "url": "https://arxiv.org/abs/2404.07972",
+          "description": "Open-ended computer-use benchmark; reports best model 12.24% vs 72.36% human success in initial results."
+        },
+        {
+          "type": "entry",
+          "name": "WebArena",
+          "url": "https://arxiv.org/abs/2307.13854",
+          "description": "Realistic web-task benchmark; reports best GPT-4-based agent at 14.41% vs 78.24% human."
+        },
+        {
+          "type": "entry",
+          "name": "GAIA",
+          "url": "https://arxiv.org/abs/2311.12983",
+          "description": "General assistant benchmark; original framing reports large human-model gap on tool-heavy questions."
+        },
+        {
+          "type": "text",
+          "text": ""
+        },
+        {
+          "type": "entry",
+          "name": "AgentBench",
+          "url": "https://github.com/THUDM/AgentBench",
+          "description": "Multi-domain benchmark suite for evaluating LLMs as agents."
+        },
+        {
+          "type": "entry",
+          "name": "AgentEvals",
+          "url": "https://github.com/langchain-ai/agentevals",
+          "description": "Evaluation utilities for scoring agent trajectories and outcomes."
+        },
+        {
+          "type": "entry",
+          "name": "AutoGen agbench",
+          "url": "https://github.com/microsoft/autogen/blob/main/python/packages/agbench/README.md",
+          "description": "Benchmark runner for AutoGen agent workflows."
+        },
+        {
+          "type": "entry",
+          "name": "BrowserGym",
+          "url": "https://github.com/ServiceNow/BrowserGym",
+          "description": "Gym-style environment for training and evaluating browser agents."
+        },
+        {
+          "type": "entry",
+          "name": "browser-use",
+          "url": "https://github.com/browser-use/browser-use",
+          "description": "Framework for browser task automation and agent web interaction loops."
+        },
+        {
+          "type": "entry",
+          "name": "Inspect AI",
+          "url": "https://github.com/UKGovernmentBEIS/inspect_ai",
+          "description": "Open-source framework for reproducible LLM and agent evaluations."
+        },
+        {
+          "type": "entry",
+          "name": "JailbreakBench",
+          "url": "https://github.com/JailbreakBench/jailbreakbench",
+          "description": "Open robustness benchmark for measuring jailbreak resistance in language models and agents."
+        },
+        {
+          "type": "entry",
+          "name": "MCPMark",
+          "url": "https://github.com/eval-sys/mcpmark",
+          "description": "Stress-testing benchmark for evaluating model and agent capability on MCP tasks."
+        },
+        {
+          "type": "entry",
+          "name": "MLE-bench",
+          "url": "https://github.com/openai/mle-bench",
+          "description": "Benchmark harness for autonomous ML engineering tasks."
+        },
+        {
+          "type": "entry",
+          "name": "OSWorld",
+          "url": "https://github.com/xlang-ai/OSWorld",
+          "description": "Open-ended benchmark environment for desktop computer-use agents."
+        },
+        {
+          "type": "entry",
+          "name": "OpenCUA",
+          "url": "https://github.com/xlang-ai/OpenCUA",
+          "description": "Open foundation stack for building and evaluating computer-use agents."
+        },
+        {
+          "type": "entry",
+          "name": "Stagehand",
+          "url": "https://github.com/browserbase/stagehand",
+          "description": "Browser automation framework for agentic web workflows and reproducible runs."
+        },
+        {
+          "type": "entry",
+          "name": "SWE-bench",
+          "url": "https://github.com/SWE-bench/SWE-bench",
+          "description": "Canonical benchmark for coding agents on real GitHub issue tasks."
+        },
+        {
+          "type": "entry",
+          "name": "Tau-Bench",
+          "url": "https://github.com/sierra-research/tau-bench",
+          "description": "Realistic interactive benchmark for measuring agent reliability."
+        },
+        {
+          "type": "entry",
+          "name": "WebArena",
+          "url": "https://github.com/web-arena-x/webarena",
+          "description": "Real-world web task benchmark environment for browser agents."
+        },
+        {
+          "type": "entry",
+          "name": "WorkArena",
+          "url": "https://github.com/ServiceNow/WorkArena",
+          "description": "Enterprise task benchmark for browser-based agent workflows."
+        },
+        {
+          "type": "entry",
+          "name": "AgentDojo",
+          "url": "https://github.com/ethz-spylab/agentdojo",
+          "description": "Security and robustness benchmark suite for tool-using agents."
+        },
+        {
+          "type": "entry",
+          "name": "AppWorld",
+          "url": "https://github.com/StonyBrookNLP/appworld",
+          "description": "Multi-application environment for benchmarking autonomous task completion."
+        },
+        {
+          "type": "entry",
+          "name": "AgentLab",
+          "url": "https://github.com/ServiceNow/AgentLab",
+          "description": "Research platform for developing and evaluating web agents."
+        },
+        {
+          "type": "entry",
+          "name": "ALFWorld",
+          "url": "https://alfworld.github.io/",
+          "description": "Interactive long-horizon benchmark environment for embodied planning agents."
+        },
+        {
+          "type": "entry",
+          "name": "HELM",
+          "url": "https://crfm.stanford.edu/helm/latest/",
+          "description": "Standardized evaluation framework for model and agent behavior comparison."
+        },
+        {
+          "type": "entry",
+          "name": "GAIA Benchmark",
+          "url": "https://huggingface.co/gaia-benchmark",
+          "description": "Realistic benchmark for tool-using, multi-step general assistant tasks."
+        },
+        {
+          "type": "entry",
+          "name": "Agent Harnessing Playbook (this repo)",
+          "url": "guides/agent-harnessing-playbook.md",
+          "description": "Practical framework for benchmark design, regression gates, and release readiness."
+        },
+        {
+          "type": "text",
+          "text": ""
+        }
+      ]
+    },
+    {
+      "name": "ArXiv Deep Research Map",
+      "items": [
+        {
+          "type": "text",
+          "text": ""
+        },
+        {
+          "type": "text",
+          "text": "Deep-dive reading map organized by the major categories in this repository."
+        },
+        {
+          "type": "text",
+          "text": ""
+        },
+        {
+          "type": "entry",
+          "name": "ArXiv Deep Research Map (this repo)",
+          "url": "guides/arxiv-deep-research-map.md",
+          "description": "Curated paper paths with per-category must-reads, a recent watchlist, and a monthly refresh workflow across frameworks, coding, MCP/tool use, eval reliability, memory, security, multimodal, quant, and on-chain/DeFi-adjacent research."
+        },
+        {
+          "type": "text",
+          "text": ""
+        }
+      ]
+    },
+    {
+      "name": "Context Engineering",
+      "items": [
+        {
+          "type": "text",
+          "text": ""
+        },
+        {
+          "type": "text",
+          "text": "Systems-level context design: memory, retrieval, compression, routing, and long-horizon state management."
+        },
+        {
+          "type": "text",
+          "text": "Focus here on *what information the model gets, when, and in what form*."
+        },
+        {
+          "type": "text",
+          "text": ""
+        },
+        {
+          "type": "entry",
+          "name": "12-Factor Agents",
+          "url": "https://github.com/humanlayer/12-factor-agents",
+          "description": "Engineering principles for building reliable, production-grade LLM agents."
+        },
+        {
+          "type": "entry",
+          "name": "Anthropic: Building Effective Agents",
+          "url": "https://www.anthropic.com/engineering/building-effective-agents",
+          "description": "Practical engineering patterns for agent design and execution loops."
+        },
+        {
+          "type": "entry",
+          "name": "Anthropic: Contextual Retrieval",
+          "url": "https://www.anthropic.com/engineering/contextual-retrieval",
+          "description": "Retrieval architecture guidance for improving grounding and precision."
+        },
+        {
+          "type": "entry",
+          "name": "Anthropic: Effective Context Engineering for AI Agents",
+          "url": "https://www.anthropic.com/engineering/effective-context-engineering-for-ai-agents",
+          "description": "Production guidance for context composition and lifecycle management."
+        },
+        {
+          "type": "entry",
+          "name": "Anthropic: Effective Harnesses for Long-Running Agents",
+          "url": "https://www.anthropic.com/engineering/effective-harnesses-for-long-running-agents",
+          "description": "Patterns for long-horizon orchestration and reliability."
+        },
+        {
+          "type": "entry",
+          "name": "LangChain: Context Engineering for Agents",
+          "url": "https://blog.langchain.com/context-engineering-for-agents/",
+          "description": "Practical taxonomy for writing, selecting, compressing, and isolating context."
+        },
+        {
+          "type": "entry",
+          "name": "Manus: Context Engineering for AI Agents",
+          "url": "https://manus.im/blog/Context-Engineering-for-AI-Agents-Lessons-from-Building-Manus",
+          "description": "Practitioner lessons from building production autonomous workflows."
+        },
+        {
+          "type": "entry",
+          "name": "Martin Fowler: Harness Engineering",
+          "url": "https://martinfowler.com/articles/exploring-gen-ai/harness-engineering.html",
+          "description": "Practitioner-oriented analysis of harness-layer reliability patterns."
+        },
+        {
+          "type": "entry",
+          "name": "OpenAI Evals Guide",
+          "url": "https://platform.openai.com/docs/guides/evals",
+          "description": "Official framework for building eval loops and quality gates."
+        },
+        {
+          "type": "entry",
+          "name": "OpenAI Cookbook: Getting Started with Evals",
+          "url": "https://developers.openai.com/cookbook/examples/evaluation/getting_started_with_openai_evals",
+          "description": "Practical eval setup walkthrough."
+        },
+        {
+          "type": "entry",
+          "name": "RAG (Lewis et al., 2020)",
+          "url": "https://arxiv.org/abs/2005.11401",
+          "description": "Foundational retrieval-augmented generation paper."
+        },
+        {
+          "type": "entry",
+          "name": "Chain-of-Thought Prompting (Wei et al., 2022)",
+          "url": "https://arxiv.org/abs/2203.02155",
+          "description": "Foundational reasoning/prompting technique paper."
+        },
+        {
+          "type": "entry",
+          "name": "Lost in the Middle (Liu et al., 2023)",
+          "url": "https://arxiv.org/abs/2307.03172",
+          "description": "Key long-context failure analysis paper."
+        },
+        {
+          "type": "entry",
+          "name": "Context Engineering Playbook (this repo)",
+          "url": "guides/context-engineering-playbook.md",
+          "description": "Practical context budget, memory, retrieval, and anti-drift checklist."
+        },
+        {
+          "type": "entry",
+          "name": "Agent Operator Trend Signals (this repo)",
+          "url": "guides/agent-operator-trend-signals-2026.md",
+          "description": "Synthesized practitioner themes for harness and context strategy."
+        },
+        {
+          "type": "text",
+          "text": ""
+        }
+      ]
+    },
+    {
+      "name": "Neural Networks and Neural Linking",
+      "items": [
+        {
+          "type": "text",
+          "text": ""
+        },
+        {
+          "type": "text",
+          "text": "Neural memory, retrieval, and graph-linking foundations relevant to advanced agent cognition."
+        },
+        {
+          "type": "text",
+          "text": ""
+        },
+        {
+          "type": "entry",
+          "name": "Neural Turing Machines (2014)",
+          "url": "https://arxiv.org/abs/1410.5401",
+          "description": "Foundational differentiable external-memory architecture."
+        },
+        {
+          "type": "entry",
+          "name": "End-to-End Memory Networks (2015)",
+          "url": "https://arxiv.org/abs/1503.08895",
+          "description": "Multi-hop memory lookup architecture for iterative reasoning."
+        },
+        {
+          "type": "entry",
+          "name": "Differentiable Neural Computer (2016)",
+          "url": "https://arxiv.org/abs/1605.08582",
+          "description": "Enhanced neural memory addressing for long-horizon reasoning."
+        },
+        {
+          "type": "entry",
+          "name": "Transformer-XL (2019)",
+          "url": "https://arxiv.org/abs/1901.02860",
+          "description": "Segment-level recurrence for long-context memory reuse."
+        },
+        {
+          "type": "entry",
+          "name": "Compressive Transformer (2019)",
+          "url": "https://arxiv.org/abs/1911.05507",
+          "description": "Compressed memory tiers for scalable sequence retention."
+        },
+        {
+          "type": "entry",
+          "name": "RAG (Lewis et al., 2020)",
+          "url": "https://arxiv.org/abs/2005.11401",
+          "description": "Canonical retrieval-augmented generation architecture."
+        },
+        {
+          "type": "entry",
+          "name": "kNN Language Models (2020)",
+          "url": "https://arxiv.org/abs/1911.00172",
+          "description": "Non-parametric memory retrieval at inference time."
+        },
+        {
+          "type": "entry",
+          "name": "RETRO (2021)",
+          "url": "https://arxiv.org/abs/2112.04426",
+          "description": "Retrieval-heavy architecture for efficient knowledge access."
+        },
+        {
+          "type": "entry",
+          "name": "Neural Bellman-Ford Networks (2021)",
+          "url": "https://arxiv.org/abs/2106.06935",
+          "description": "Graph neural reasoning for multi-hop relational inference."
+        },
+        {
+          "type": "entry",
+          "name": "DeepProbLog",
+          "url": "https://github.com/ML-KULeuven/deepproblog",
+          "description": "Neural-symbolic framework combining perception models and logic rules."
+        },
+        {
+          "type": "entry",
+          "name": "Neural Linking and Memory Playbook (this repo)",
+          "url": "guides/neural-linking-memory-playbook.md",
+          "description": "Practical guide for agent memory architectures and neural-symbolic linking patterns."
+        },
+        {
+          "type": "text",
+          "text": ""
+        }
+      ]
+    },
+    {
+      "name": "Obsidian Vault Architecture for Agents",
+      "items": [
+        {
+          "type": "text",
+          "text": ""
+        },
+        {
+          "type": "text",
+          "text": "Obsidian-specific architecture patterns and APIs for using vaults as agent memory backends."
+        },
+        {
+          "type": "text",
+          "text": ""
+        },
+        {
+          "type": "entry",
+          "name": "How Obsidian Stores Data",
+          "url": "https://help.obsidian.md/Files+and+folders/How+Obsidian+stores+data",
+          "description": "Canonical vault-on-disk model and config layout."
+        },
+        {
+          "type": "entry",
+          "name": "Obsidian Properties",
+          "url": "https://help.obsidian.md/Editing+and+formatting/Properties",
+          "description": "Structured metadata schema for machine-readable note attributes."
+        },
+        {
+          "type": "entry",
+          "name": "Obsidian Plugin Guide",
+          "url": "https://docs.obsidian.md/Plugins/Getting+started/Build+a+plugin",
+          "description": "Official plugin architecture and lifecycle entrypoint."
+        },
+        {
+          "type": "entry",
+          "name": "Obsidian TypeScript API (Vault)",
+          "url": "https://docs.obsidian.md/Reference/TypeScript+API/Vault",
+          "description": "Programmatic CRUD layer for vault files."
+        },
+        {
+          "type": "entry",
+          "name": "obsidian-api",
+          "url": "https://github.com/obsidianmd/obsidian-api",
+          "description": "Official API type definitions for plugin development."
+        },
+        {
+          "type": "entry",
+          "name": "Dataview",
+          "url": "https://github.com/blacksmithgu/obsidian-dataview",
+          "description": "Query engine for structured note metadata and graph-aware retrieval."
+        },
+        {
+          "type": "entry",
+          "name": "Juggl",
+          "url": "https://github.com/HEmile/juggl",
+          "description": "Advanced graph exploration plugin for complex link topology workflows."
+        },
+        {
+          "type": "entry",
+          "name": "Local REST API Plugin",
+          "url": "https://github.com/coddingtonbear/obsidian-local-rest-api",
+          "description": "Local HTTP interface for external agent integrations."
+        },
+        {
+          "type": "entry",
+          "name": "Advanced URI",
+          "url": "https://github.com/Vinzent03/obsidian-advanced-uri",
+          "description": "URI-based automation hooks for cross-tool workflows."
+        },
+        {
+          "type": "entry",
+          "name": "Obsidian Git",
+          "url": "https://github.com/Vinzent03/obsidian-git",
+          "description": "Versioned vault operations for auditable agent writes."
+        },
+        {
+          "type": "entry",
+          "name": "Obsidian Vault Architecture Playbook (this repo)",
+          "url": "guides/obsidian-vault-architecture-playbook.md",
+          "description": "Reference architecture and operational patterns for agent-connected Obsidian systems."
+        },
+        {
+          "type": "text",
+          "text": ""
+        }
+      ]
+    },
+    {
+      "name": "Agent Security and Robustness",
+      "items": [
+        {
+          "type": "text",
+          "text": ""
+        },
+        {
+          "type": "text",
+          "text": "Safety, red-teaming, and robustness tools for hardening agent behavior."
+        },
+        {
+          "type": "text",
+          "text": ""
+        },
+        {
+          "type": "entry",
+          "name": "DeepTeam",
+          "url": "https://github.com/confident-ai/deepteam",
+          "description": "Framework for red-teaming LLMs and agent systems with automated attack generation and scoring."
+        },
+        {
+          "type": "entry",
+          "name": "garak",
+          "url": "https://github.com/NVIDIA/garak",
+          "description": "LLM vulnerability scanning and red-teaming toolkit for security testing."
+        },
+        {
+          "type": "entry",
+          "name": "Guardrails AI",
+          "url": "https://github.com/guardrails-ai/guardrails",
+          "description": "Validation and safety guardrails framework for LLM outputs."
+        },
+        {
+          "type": "entry",
+          "name": "Invariant",
+          "url": "https://github.com/invariantlabs-ai/invariant",
+          "description": "Guardrails framework for secure and robust agent development."
+        },
+        {
+          "type": "entry",
+          "name": "JailbreakBench",
+          "url": "https://github.com/JailbreakBench/jailbreakbench",
+          "description": "Open robustness benchmark for measuring jailbreak resistance in language models and agents."
+        },
+        {
+          "type": "entry",
+          "name": "llm-attacks",
+          "url": "https://github.com/llm-attacks/llm-attacks",
+          "description": "Reference implementation and resources for adversarial jailbreak attack evaluation."
+        },
+        {
+          "type": "entry",
+          "name": "MCP Security Best Practices",
+          "url": "https://modelcontextprotocol.io/docs/tutorials/security/security_best_practices",
+          "description": "Official security guidance for MCP authorization flows, threats, and mitigations."
+        },
+        {
+          "type": "entry",
+          "name": "Microsoft Agent Governance Toolkit",
+          "url": "https://github.com/microsoft/agent-governance-toolkit",
+          "description": "Policy enforcement and zero-trust governance toolkit for autonomous AI agent deployments."
+        },
+        {
+          "type": "entry",
+          "name": "NeMo Guardrails",
+          "url": "https://github.com/NVIDIA-NeMo/Guardrails",
+          "description": "Toolkit for adding programmable safety and policy guardrails to LLM systems."
+        },
+        {
+          "type": "entry",
+          "name": "Promptfoo",
+          "url": "https://github.com/promptfoo/promptfoo",
+          "description": "Red-teaming and robustness testing toolkit for LLM systems."
+        },
+        {
+          "type": "text",
+          "text": ""
+        },
+        {
+          "type": "entry",
+          "name": "PyRIT",
+          "url": "https://github.com/Azure/PyRIT",
+          "description": "Python Risk Identification Tool for proactively testing generative AI security risks."
+        },
+        {
+          "type": "entry",
+          "name": "Qualys TotalAI MCP Security",
+          "url": "https://blog.qualys.com/product-tech/2026/03/19/mcp-servers-shadow-it-ai-qualys-totalai-2026",
+          "description": "MCP server security assessment and shadow IT detection for enterprise environments."
+        }
+      ]
+    },
+    {
+      "name": "Agent Configs and Dotfiles",
+      "items": [
+        {
+          "type": "text",
+          "text": ""
+        },
+        {
+          "type": "text",
+          "text": "Configuration files and workflow examples for AI coding tools."
+        },
+        {
+          "type": "text",
+          "text": ""
+        },
+        {
+          "type": "entry",
+          "name": "AGENTS.md",
+          "url": "https://github.com/agentsmd/agents.md",
+          "description": "Open format for repository-scoped instructions that guide coding agents across tools."
+        },
+        {
+          "type": "entry",
+          "name": "awesome-cursorrules",
+          "url": "https://github.com/PatrickJS/awesome-cursorrules",
+          "description": "Curated list of Cursor rule files."
+        },
+        {
+          "type": "entry",
+          "name": "Claude Code Memory Files",
+          "url": "https://docs.anthropic.com/en/docs/claude-code/memory",
+          "description": "Guide to CLAUDE.md and project memory."
+        },
+        {
+          "type": "entry",
+          "name": "Claude Code Starter Configs",
+          "url": "claude/",
+          "description": "Ready-to-use CLAUDE.md, rules, hooks, and skills for Claude Code projects."
+        },
+        {
+          "type": "entry",
+          "name": "Codex CLI Starter Configs",
+          "url": "codex/",
+          "description": "Ready-to-use AGENTS.md and config for OpenAI Codex CLI projects."
+        },
+        {
+          "type": "entry",
+          "name": "Cursor Starter Configs",
+          "url": "cursorrules/",
+          "description": "Ready-to-use .cursorrules and rule files for Cursor projects."
+        },
+        {
+          "type": "entry",
+          "name": "CursorDirectory",
+          "url": "https://cursor.directory",
+          "description": "Community-shared Cursor rules and configurations."
+        },
+        {
+          "type": "entry",
+          "name": "dotfiles",
+          "url": "https://dotfiles.github.io",
+          "description": "Guide to managing dotfiles including agent configurations."
+        },
+        {
+          "type": "entry",
+          "name": "Ruler",
+          "url": "https://github.com/intellectronica/ruler",
+          "description": "Policy layer for applying consistent coding rules across different AI coding agents."
+        },
+        {
+          "type": "text",
+          "text": ""
+        },
+        {
+          "type": "entry",
+          "name": "Superpowers",
+          "url": "https://github.com/obra/superpowers",
+          "description": "Shell-based agentic skills methodology with composable capability configs."
+        },
+        {
+          "type": "entry",
+          "name": "Trail of Bits Claude Code Config",
+          "url": "https://github.com/trailofbits/claude-code-config",
+          "description": "Opinionated Claude Code defaults and workflows from a security-focused engineering team."
+        }
+      ]
+    },
+    {
+      "name": "Skill Engineering and Playbooks",
+      "items": [
+        {
+          "type": "text",
+          "text": ""
+        },
+        {
+          "type": "text",
+          "text": "Hands-on resources for designing, testing, and shipping high-quality agent skills."
+        },
+        {
+          "type": "text",
+          "text": ""
+        },
+        {
+          "type": "entry",
+          "name": "Agent Skills for Context Engineering",
+          "url": "https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering",
+          "description": "Collection of agent skills for context engineering, multi-agent architectures, and production systems."
+        },
+        {
+          "type": "entry",
+          "name": "Agent Skills for LLMs (paper)",
+          "url": "https://arxiv.org/abs/2602.12430",
+          "description": "Research on skill augmentation design principles and effectiveness for LLM-based agents."
+        },
+        {
+          "type": "entry",
+          "name": "AgentSkills Specification",
+          "url": "https://github.com/agentskills/agentskills",
+          "description": "Open specification and documentation for portable agent skill packaging and execution semantics."
+        },
+        {
+          "type": "entry",
+          "name": "Anthropic: The Complete Guide to Building Skills for Claude (PDF)",
+          "url": "https://resources.anthropic.com/hubfs/The-Complete-Guide-to-Building-Skill-for-Claude.pdf",
+          "description": "Canonical end-to-end guide covering structure, triggering, testing, and distribution."
+        },
+        {
+          "type": "entry",
+          "name": "anthropics/skills",
+          "url": "https://github.com/anthropics/skills",
+          "description": "Official production-ready skill examples and reference implementations."
+        },
+        {
+          "type": "entry",
+          "name": "Claude Skill Engineering Playbook (this repo)",
+          "url": "guides/claude-skill-engineering-playbook.md",
+          "description": "Distilled patterns, anti-patterns, templates, and troubleshooting from the Anthropic guide."
+        },
+        {
+          "type": "entry",
+          "name": "Claude Skills Quickstart Checklist (this repo)",
+          "url": "guides/claude-skills-quickstart-checklist.md",
+          "description": "Build-test-ship checklist for repeatable skill quality."
+        },
+        {
+          "type": "entry",
+          "name": "OpenAI Skills",
+          "url": "https://github.com/openai/skills",
+          "description": "Official Codex skills catalog with reusable workflows and integrations."
+        },
+        {
+          "type": "entry",
+          "name": "SkillsBench",
+          "url": "https://arxiv.org/html/2602.12670v1",
+          "description": "Benchmark for evaluating how well agent skills work across diverse tasks and harness configurations."
+        },
+        {
+          "type": "text",
+          "text": ""
+        },
+        {
+          "type": "entry",
+          "name": "Spring AI Agent Skills",
+          "url": "https://spring.io/blog/2026/01/13/spring-ai-generic-agent-skills/",
+          "description": "Modular, reusable skill capabilities for the Spring AI Java ecosystem."
+        },
+        {
+          "type": "entry",
+          "name": "Superpowers",
+          "url": "https://github.com/obra/superpowers",
+          "description": "Agentic skills framework and software development methodology with composable skill architecture."
+        },
+        {
+          "type": "entry",
+          "name": "Vercel Agent Skills",
+          "url": "https://github.com/vercel-labs/agent-skills",
+          "description": "Official production skill collection for building and sharing reusable agent capabilities."
+        }
+      ]
+    },
+    {
+      "name": "Knowledge Graphs and Memory",
+      "items": [
+        {
+          "type": "text",
+          "text": ""
+        },
+        {
+          "type": "text",
+          "text": "Agent memory architectures, knowledge graphs, and second-brain integrations."
+        },
+        {
+          "type": "text",
+          "text": ""
+        },
+        {
+          "type": "entry",
+          "name": "Cognee",
+          "url": "https://github.com/topoteretes/cognee",
+          "description": "Memory management layer for LLM apps using knowledge graphs."
+        },
+        {
+          "type": "entry",
+          "name": "FalkorDB",
+          "url": "https://github.com/FalkorDB/FalkorDB",
+          "description": "Ultra-fast graph database for AI agent knowledge."
+        },
+        {
+          "type": "entry",
+          "name": "Graphiti",
+          "url": "https://github.com/getzep/graphiti",
+          "description": "Real-time knowledge graph framework for AI agents."
+        },
+        {
+          "type": "entry",
+          "name": "GraphRAG",
+          "url": "https://github.com/microsoft/graphrag",
+          "description": "Graph-based retrieval augmented generation from Microsoft."
+        },
+        {
+          "type": "entry",
+          "name": "Khoj",
+          "url": "https://github.com/khoj-ai/khoj",
+          "description": "Personal AI assistant with long-term memory and knowledge search."
+        },
+        {
+          "type": "entry",
+          "name": "LangMem",
+          "url": "https://github.com/langchain-ai/langmem",
+          "description": "Memory management toolkit for building long-horizon agent systems."
+        },
+        {
+          "type": "entry",
+          "name": "LightRAG",
+          "url": "https://github.com/HKUDS/LightRAG",
+          "description": "Simple and fast RAG framework using graph structures."
+        },
+        {
+          "type": "entry",
+          "name": "Mem0",
+          "url": "https://github.com/mem0ai/mem0",
+          "description": "Memory layer for AI assistants and agents."
+        },
+        {
+          "type": "entry",
+          "name": "Memgraph",
+          "url": "https://github.com/memgraph/memgraph",
+          "description": "In-memory graph database for real-time agent queries."
+        },
+        {
+          "type": "entry",
+          "name": "Neo4j",
+          "url": "https://github.com/neo4j/neo4j",
+          "description": "Graph database platform widely used for agent knowledge stores."
+        },
+        {
+          "type": "entry",
+          "name": "Obsidian",
+          "url": "https://obsidian.md",
+          "description": "Knowledge base and note-taking app usable as agent memory backend."
+        },
+        {
+          "type": "entry",
+          "name": "obsidian-graph-query",
+          "url": "https://github.com/azuma520/obsidian-graph-query",
+          "description": "Query and traverse Obsidian vault graphs programmatically."
+        },
+        {
+          "type": "entry",
+          "name": "ODIN",
+          "url": "https://github.com/memgraph/odin",
+          "description": "Knowledge graph construction tool built on Memgraph."
+        },
+        {
+          "type": "entry",
+          "name": "Pinecone",
+          "url": "https://www.pinecone.io",
+          "description": "Vector database for semantic memory and retrieval."
+        },
+        {
+          "type": "entry",
+          "name": "Qdrant",
+          "url": "https://github.com/qdrant/qdrant",
+          "description": "High-performance vector search engine for agent memory."
+        },
+        {
+          "type": "entry",
+          "name": "txtai",
+          "url": "https://github.com/neuml/txtai",
+          "description": "All-in-one embeddings database for semantic search and workflows."
+        },
+        {
+          "type": "entry",
+          "name": "Weaviate",
+          "url": "https://github.com/weaviate/weaviate",
+          "description": "Vector database with built-in modules for AI workloads."
+        },
+        {
+          "type": "entry",
+          "name": "Zep",
+          "url": "https://github.com/getzep/zep",
+          "description": "Memory infrastructure and retrieval stack for AI assistants and agents."
+        },
+        {
+          "type": "text",
+          "text": ""
+        }
+      ]
+    },
+    {
+      "name": "Solana Agent Infrastructure",
+      "items": [
+        {
+          "type": "text",
+          "text": ""
+        },
+        {
+          "type": "text",
+          "text": "Tools and SDKs for building AI agents on Solana."
+        },
+        {
+          "type": "text",
+          "text": ""
+        },
+        {
+          "type": "entry",
+          "name": "Anchor",
+          "url": "https://github.com/solana-foundation/anchor",
+          "description": "Core Solana framework for building and integrating smart contracts and clients."
+        },
+        {
+          "type": "entry",
+          "name": "Awesome Solana AI",
+          "url": "https://github.com/solana-foundation/awesome-solana-ai",
+          "description": "Solana Foundation's curated list of AI-Solana projects."
+        },
+        {
+          "type": "entry",
+          "name": "GOAT SDK",
+          "url": "https://github.com/goat-sdk/goat",
+          "description": "Open-source toolkit connecting AI agents to 200+ on-chain tools across Solana and EVM chains."
+        },
+        {
+          "type": "entry",
+          "name": "Helius SDK",
+          "url": "https://github.com/helius-labs/helius-sdk",
+          "description": "TypeScript SDK for Solana RPC, webhooks, and DAS API."
+        },
+        {
+          "type": "entry",
+          "name": "Jito-Solana",
+          "url": "https://github.com/jito-foundation/jito-solana",
+          "description": "MEV-aware Solana client infrastructure for advanced execution agents."
+        },
+        {
+          "type": "entry",
+          "name": "Jupiter Swap API Docs",
+          "url": "https://dev.jup.ag/docs/swap-api",
+          "description": "Official documentation for integrating Jupiter routing and swaps."
+        },
+        {
+          "type": "entry",
+          "name": "LangChain Solana Agent Kit",
+          "url": "https://github.com/sendaifun/solana-agent-kit",
+          "description": "LangChain tools for Solana agent operations."
+        },
+        {
+          "type": "entry",
+          "name": "Light Protocol",
+          "url": "https://github.com/Lightprotocol/light-protocol",
+          "description": "ZK compression for scalable on-chain agent state."
+        },
+        {
+          "type": "entry",
+          "name": "Metaplex",
+          "url": "https://github.com/metaplex-foundation/metaplex-program-library",
+          "description": "Solana programs for NFTs and digital assets used in agent identity."
+        },
+        {
+          "type": "entry",
+          "name": "Pyth Crosschain",
+          "url": "https://github.com/pyth-network/pyth-crosschain",
+          "description": "Oracle infrastructure for low-latency market data used by agent strategies."
+        },
+        {
+          "type": "entry",
+          "name": "Solana Actions",
+          "url": "https://github.com/solana-developers/solana-actions",
+          "description": "Spec and tools for blockchain-powered actions and blinks."
+        },
+        {
+          "type": "entry",
+          "name": "Solana Agent Kit",
+          "url": "https://github.com/sendaifun/solana-agent-kit",
+          "description": "Toolkit for connecting AI agents to Solana protocols."
+        },
+        {
+          "type": "entry",
+          "name": "Solana Kit",
+          "url": "https://github.com/anza-xyz/kit",
+          "description": "Modern Solana client SDK stack for building high-quality applications and agents."
+        },
+        {
+          "type": "entry",
+          "name": "Solana Web3.js",
+          "url": "https://github.com/solana-labs/solana-web3.js",
+          "description": "JavaScript SDK for interacting with the Solana blockchain."
+        },
+        {
+          "type": "entry",
+          "name": "Switchboard Solana SDK",
+          "url": "https://github.com/switchboard-xyz/solana-sdk",
+          "description": "Verifiable oracle and data-feed SDK for agent decision systems."
+        },
+        {
+          "type": "entry",
+          "name": "Yellowstone gRPC",
+          "url": "https://github.com/rpcpool/yellowstone-grpc",
+          "description": "High-throughput real-time Solana data streams for low-latency agents and indexers."
+        },
+        {
+          "type": "entry",
+          "name": "Solana Agent Architecture Playbook (this repo)",
+          "url": "guides/solana-agent-architecture-playbook.md",
+          "description": "Reference architecture, security controls, and ops checklist for production Solana agents."
+        },
+        {
+          "type": "text",
+          "text": ""
+        }
+      ]
+    },
+    {
+      "name": "Agent Identity and Wallets",
+      "items": [
+        {
+          "type": "text",
+          "text": ""
+        },
+        {
+          "type": "text",
+          "text": "On-chain identity, wallets, and trust infrastructure for autonomous AI agents."
+        },
+        {
+          "type": "text",
+          "text": ""
+        },
+        {
+          "type": "entry",
+          "name": "Coinbase AgentKit",
+          "url": "https://github.com/coinbase/agentkit",
+          "description": "Toolkit for giving AI agents programmable wallet capabilities."
+        },
+        {
+          "type": "entry",
+          "name": "Crossmint",
+          "url": "https://www.crossmint.com",
+          "description": "Wallet-as-a-service for agent-owned wallets and NFT minting."
+        },
+        {
+          "type": "entry",
+          "name": "EIP-1271",
+          "url": "https://eips.ethereum.org/EIPS/eip-1271",
+          "description": "Standard for contract wallet signature validation in dapps and agent auth flows."
+        },
+        {
+          "type": "entry",
+          "name": "EIP-4337",
+          "url": "https://eips.ethereum.org/EIPS/eip-4337",
+          "description": "Account abstraction standard enabling programmable smart accounts for agents."
+        },
+        {
+          "type": "entry",
+          "name": "EIP-4361 (SIWE)",
+          "url": "https://eips.ethereum.org/EIPS/eip-4361",
+          "description": "Sign-In with Ethereum standard for wallet-based authentication."
+        },
+        {
+          "type": "entry",
+          "name": "EIP-7702",
+          "url": "https://eips.ethereum.org/EIPS/eip-7702",
+          "description": "EOA delegation model for temporary smart-account-like behavior."
+        },
+        {
+          "type": "entry",
+          "name": "ERC-7579",
+          "url": "https://ercs.ethereum.org/ERCS/erc-7579",
+          "description": "Modular smart account standard for plugin-based permissions and execution."
+        },
+        {
+          "type": "entry",
+          "name": "ERC-8004",
+          "url": "https://eips.ethereum.org/EIPS/eip-8004",
+          "description": "Proposed standard for cross-chain agent identity."
+        },
+        {
+          "type": "entry",
+          "name": "Lit Protocol",
+          "url": "https://github.com/LIT-Protocol/js-sdk",
+          "description": "Decentralized key management and programmable signing."
+        },
+        {
+          "type": "entry",
+          "name": "Privy",
+          "url": "https://www.privy.io",
+          "description": "Embedded wallet infrastructure for agent authentication."
+        },
+        {
+          "type": "entry",
+          "name": "Safe",
+          "url": "https://github.com/safe-global/safe-smart-account",
+          "description": "Multi-signature smart account for EVM agent treasuries."
+        },
+        {
+          "type": "entry",
+          "name": "Sign-In With Solana",
+          "url": "https://github.com/phantom/sign-in-with-solana",
+          "description": "Wallet-native authentication pattern for Solana apps and agents."
+        },
+        {
+          "type": "entry",
+          "name": "Solana Agent Identity",
+          "url": "https://github.com/sendaifun/solana-agent-kit",
+          "description": "Agent wallet and identity features in Solana Agent Kit."
+        },
+        {
+          "type": "entry",
+          "name": "Squads Protocol",
+          "url": "https://github.com/Squads-Protocol/v4",
+          "description": "Multisig and smart account protocol for Solana agents."
+        },
+        {
+          "type": "entry",
+          "name": "Turnkey",
+          "url": "https://www.turnkey.com",
+          "description": "Secure key infrastructure for programmatic wallet management."
+        },
+        {
+          "type": "entry",
+          "name": "UCAN",
+          "url": "https://github.com/ucan-wg/spec",
+          "description": "User-controlled authorization for decentralized agent capabilities."
+        },
+        {
+          "type": "text",
+          "text": ""
+        }
+      ]
+    },
+    {
+      "name": "Agent Payments",
+      "items": [
+        {
+          "type": "text",
+          "text": ""
+        },
+        {
+          "type": "text",
+          "text": "Payment protocols and infrastructure for autonomous agent transactions."
+        },
+        {
+          "type": "text",
+          "text": ""
+        },
+        {
+          "type": "entry",
+          "name": "Awesome x402",
+          "url": "https://github.com/Merit-Systems/awesome-x402",
+          "description": "Curated resources for the x402 payment protocol ecosystem."
+        },
+        {
+          "type": "entry",
+          "name": "Coinbase Agentic Wallets",
+          "url": "https://www.coinbase.com/developer-platform/discover/launches/agentic-wallets",
+          "description": "Wallet infrastructure for AI agents with programmable spending limits."
+        },
+        {
+          "type": "entry",
+          "name": "Google A2A x402 Extension",
+          "url": "https://github.com/google-agentic-commerce/a2a-x402",
+          "description": "Cryptocurrency payments for the Agent-to-Agent protocol via x402."
+        },
+        {
+          "type": "entry",
+          "name": "lobster.cash",
+          "url": "https://www.lobster.cash",
+          "description": "Agent payment solution on Solana with Visa Intelligent Commerce integration by Crossmint."
+        },
+        {
+          "type": "entry",
+          "name": "Request Network",
+          "url": "https://request.network",
+          "description": "Crypto-native invoicing and payment request rails for agent billing workflows."
+        },
+        {
+          "type": "entry",
+          "name": "Skyfire",
+          "url": "https://www.skyfire.xyz",
+          "description": "Know Your Agent infrastructure for accountable autonomous commerce, backed by a16z."
+        },
+        {
+          "type": "entry",
+          "name": "Solana Pay",
+          "url": "https://solanapay.com",
+          "description": "Open payments standard for Solana-based checkout and transfer flows."
+        },
+        {
+          "type": "entry",
+          "name": "Stripe Tempo",
+          "url": "https://tempo.network",
+          "description": "Payments-focused blockchain with Machine Payments Protocol for AI agent autonomous transactions."
+        },
+        {
+          "type": "entry",
+          "name": "Superfluid",
+          "url": "https://superfluid.org",
+          "description": "Streaming payment primitives for machine-to-machine and agent subscriptions."
+        },
+        {
+          "type": "entry",
+          "name": "x402 Foundation",
+          "url": "https://www.x402.org",
+          "description": "Open protocol foundation governing the x402 payment standard."
+        },
+        {
+          "type": "entry",
+          "name": "x402 Protocol",
+          "url": "https://github.com/coinbase/x402",
+          "description": "Open HTTP payment protocol using the 402 status code for agent-to-service payments."
+        },
+        {
+          "type": "text",
+          "text": ""
+        }
+      ]
+    },
+    {
+      "name": "DeFi Agents",
+      "items": [
+        {
+          "type": "text",
+          "text": ""
+        },
+        {
+          "type": "text",
+          "text": "AI agents for decentralized finance operations and strategy."
+        },
+        {
+          "type": "text",
+          "text": ""
+        },
+        {
+          "type": "entry",
+          "name": "Autonolas",
+          "url": "https://github.com/valory-xyz/open-autonomy",
+          "description": "Framework for building autonomous agent services on-chain."
+        },
+        {
+          "type": "entry",
+          "name": "DeFi Llama API",
+          "url": "https://defillama.com/docs/api",
+          "description": "Open API for DeFi protocol data used by trading agents."
+        },
+        {
+          "type": "entry",
+          "name": "Drift Protocol v2",
+          "url": "https://github.com/drift-labs/protocol-v2",
+          "description": "On-chain perpetuals protocol infrastructure for autonomous trading agents."
+        },
+        {
+          "type": "entry",
+          "name": "ElizaOS DeFi Plugins",
+          "url": "https://github.com/elizaOS/eliza/tree/main/packages",
+          "description": "DeFi protocol integrations for ElizaOS agents."
+        },
+        {
+          "type": "entry",
+          "name": "Gauntlet",
+          "url": "https://www.gauntlet.xyz",
+          "description": "Risk management and simulation platform for DeFi agents."
+        },
+        {
+          "type": "entry",
+          "name": "Griffain",
+          "url": "https://griffain.com",
+          "description": "AI agent platform for Solana DeFi operations."
+        },
+        {
+          "type": "entry",
+          "name": "Kamino KLend SDK",
+          "url": "https://github.com/Kamino-Finance/klend-sdk",
+          "description": "Lending protocol SDK for credit and yield allocation agents."
+        },
+        {
+          "type": "entry",
+          "name": "Lulo",
+          "url": "https://lulo.fi",
+          "description": "Yield optimization protocol with agent-friendly APIs."
+        },
+        {
+          "type": "entry",
+          "name": "Orca Whirlpools SDK",
+          "url": "https://github.com/orca-so/whirlpools",
+          "description": "Solana concentrated liquidity SDK for agent strategies."
+        },
+        {
+          "type": "entry",
+          "name": "Raydium SDK",
+          "url": "https://github.com/raydium-io/raydium-sdk-V2",
+          "description": "Solana AMM SDK for agent-driven liquidity provision."
+        },
+        {
+          "type": "entry",
+          "name": "Spectral Finance",
+          "url": "https://www.spectral.finance",
+          "description": "On-chain credit scoring and risk models for agent decisions."
+        },
+        {
+          "type": "entry",
+          "name": "Virtuals Protocol",
+          "url": "https://www.virtuals.io",
+          "description": "Agent tokenization and autonomous commerce protocol tracking agentic GDP."
+        },
+        {
+          "type": "entry",
+          "name": "Yearn Vaults",
+          "url": "https://github.com/yearn/yearn-vaults-v3",
+          "description": "Automated yield vaults usable as agent strategy backends."
+        },
+        {
+          "type": "text",
+          "text": ""
+        }
+      ]
+    },
+    {
+      "name": "Quant and Trading Agents",
+      "items": [
+        {
+          "type": "text",
+          "text": ""
+        },
+        {
+          "type": "text",
+          "text": "Quantitative finance frameworks and AI-driven trading systems."
+        },
+        {
+          "type": "text",
+          "text": ""
+        },
+        {
+          "type": "entry",
+          "name": "AlphaAgent",
+          "url": "https://github.com/LLMQuant/AlphaAgent",
+          "description": "LLM-powered agent for quantitative trading research."
+        },
+        {
+          "type": "entry",
+          "name": "BitQuant",
+          "url": "https://github.com/OpenGradient/BitQuant",
+          "description": "Multi-agent quantitative analysis framework."
+        },
+        {
+          "type": "entry",
+          "name": "DriftPy",
+          "url": "https://github.com/drift-labs/driftpy",
+          "description": "Python SDK for building Solana-based perp and risk management agents."
+        },
+        {
+          "type": "entry",
+          "name": "FinGPT",
+          "url": "https://github.com/AI4Finance-Foundation/FinGPT",
+          "description": "Open-source financial LLM framework."
+        },
+        {
+          "type": "entry",
+          "name": "FinRL",
+          "url": "https://github.com/AI4Finance-Foundation/FinRL",
+          "description": "Deep reinforcement learning library for quantitative finance."
+        },
+        {
+          "type": "entry",
+          "name": "Freqtrade",
+          "url": "https://github.com/freqtrade/freqtrade",
+          "description": "Open-source algorithmic trading bot in Python."
+        },
+        {
+          "type": "entry",
+          "name": "Hummingbot",
+          "url": "https://github.com/hummingbot/hummingbot",
+          "description": "Open-source market making and arbitrage bot."
+        },
+        {
+          "type": "entry",
+          "name": "Lean",
+          "url": "https://github.com/QuantConnect/Lean",
+          "description": "Algorithmic trading engine by QuantConnect."
+        },
+        {
+          "type": "entry",
+          "name": "MiroFish",
+          "url": "https://github.com/666ghj/MiroFish",
+          "description": "Multi-agent swarm intelligence engine for scenario simulation and market prediction workflows."
+        },
+        {
+          "type": "entry",
+          "name": "NautilusTrader",
+          "url": "https://github.com/nautechsystems/nautilus_trader",
+          "description": "High-performance algorithmic trading platform in Rust and Python."
+        },
+        {
+          "type": "entry",
+          "name": "Phoenix v1",
+          "url": "https://github.com/Ellipsis-Labs/phoenix-v1",
+          "description": "On-chain central limit order book protocol for low-latency execution agents."
+        },
+        {
+          "type": "entry",
+          "name": "Qlib",
+          "url": "https://github.com/microsoft/qlib",
+          "description": "AI-oriented quantitative investment platform from Microsoft."
+        },
+        {
+          "type": "entry",
+          "name": "TradingAgents",
+          "url": "https://github.com/TauricResearch/TradingAgents",
+          "description": "Multi-agent LLM framework simulating a trading firm."
+        },
+        {
+          "type": "entry",
+          "name": "VectorBT",
+          "url": "https://github.com/polakowo/vectorbt",
+          "description": "Fast backtesting and analysis library for trading strategies."
+        },
+        {
+          "type": "entry",
+          "name": "Zipline",
+          "url": "https://github.com/stefan-jansen/zipline-reloaded",
+          "description": "Pythonic algorithmic trading library for backtesting."
+        },
+        {
+          "type": "text",
+          "text": ""
+        }
+      ]
+    },
+    {
+      "name": "Agent Observability and Testing",
+      "items": [
+        {
+          "type": "text",
+          "text": ""
+        },
+        {
+          "type": "text",
+          "text": "Debugging, tracing, evaluation, and testing tools for AI agents."
+        },
+        {
+          "type": "text",
+          "text": ""
+        },
+        {
+          "type": "entry",
+          "name": "AgentOps",
+          "url": "https://github.com/AgentOps-AI/agentops",
+          "description": "Monitoring, cost tracking, and benchmarking for agent workflows."
+        },
+        {
+          "type": "entry",
+          "name": "Braintrust",
+          "url": "https://www.braintrust.dev",
+          "description": "Evaluation and observability platform for AI products."
+        },
+        {
+          "type": "entry",
+          "name": "DeepEval",
+          "url": "https://github.com/confident-ai/deepeval",
+          "description": "Open-source LLM evaluation framework."
+        },
+        {
+          "type": "entry",
+          "name": "Helicone",
+          "url": "https://github.com/Helicone/helicone",
+          "description": "Open-source LLM observability and monitoring platform."
+        },
+        {
+          "type": "entry",
+          "name": "LangFuse",
+          "url": "https://github.com/langfuse/langfuse",
+          "description": "Open-source LLM engineering platform for tracing and evaluation."
+        },
+        {
+          "type": "entry",
+          "name": "LangSmith",
+          "url": "https://smith.langchain.com",
+          "description": "Platform for debugging, testing, and monitoring LLM applications."
+        },
+        {
+          "type": "entry",
+          "name": "LangWatch",
+          "url": "https://github.com/langwatch/langwatch",
+          "description": "Open platform for LLM evaluations and agent testing with trace-centric diagnostics."
+        },
+        {
+          "type": "entry",
+          "name": "LiteLLM",
+          "url": "https://github.com/BerriAI/litellm",
+          "description": "LLM gateway and proxy with logging, cost tracking, and routing controls."
+        },
+        {
+          "type": "entry",
+          "name": "OpenAI Evals",
+          "url": "https://github.com/openai/evals",
+          "description": "Framework and benchmark registry for evaluating LLM systems."
+        },
+        {
+          "type": "entry",
+          "name": "OpenLLMetry",
+          "url": "https://github.com/traceloop/openllmetry",
+          "description": "OpenTelemetry-based observability for LLM applications."
+        },
+        {
+          "type": "entry",
+          "name": "Opik",
+          "url": "https://github.com/comet-ml/opik",
+          "description": "Open-source platform for LLM and agent tracing, evaluation, and monitoring."
+        },
+        {
+          "type": "entry",
+          "name": "Phoenix",
+          "url": "https://github.com/Arize-ai/phoenix",
+          "description": "Open-source AI observability platform from Arize."
+        },
+        {
+          "type": "entry",
+          "name": "Portkey",
+          "url": "https://github.com/Portkey-AI/gateway",
+          "description": "AI gateway with observability, caching, and fallback routing."
+        },
+        {
+          "type": "entry",
+          "name": "SigNoz",
+          "url": "https://github.com/SigNoz/signoz",
+          "description": "OpenTelemetry-native observability platform for traces, logs, and metrics."
+        },
+        {
+          "type": "entry",
+          "name": "TruLens",
+          "url": "https://github.com/truera/trulens",
+          "description": "Open-source framework for evaluating and tracking LLM and agent experiments."
+        },
+        {
+          "type": "text",
+          "text": ""
+        },
+        {
+          "type": "entry",
+          "name": "Weave",
+          "url": "https://github.com/wandb/weave",
+          "description": "Toolkit for tracking and evaluating LLM applications from W&B."
+        }
+      ]
+    },
+    {
+      "name": "Research Papers",
+      "items": [
+        {
+          "type": "text",
+          "text": ""
+        },
+        {
+          "type": "text",
+          "text": "Curated papers on AI agents, multi-agent systems, and agent infrastructure."
+        },
+        {
+          "type": "text",
+          "text": ""
+        },
+        {
+          "type": "text",
+          "text": ""
+        },
+        {
+          "type": "entry",
+          "name": "A Survey on Large Language Model based Autonomous Agents",
+          "url": "https://arxiv.org/abs/2308.11432",
+          "description": "Comprehensive survey of LLM-based agent architectures."
+        },
+        {
+          "type": "entry",
+          "name": "ArXiv Deep Research Map (this repo)",
+          "url": "guides/arxiv-deep-research-map.md",
+          "description": "Category-by-category reading map spanning frameworks, coding, MCP/tool use, memory, security, multimodal, and quant/on-chain adjacent domains."
+        },
+        {
+          "type": "entry",
+          "name": "Awesome AI Agent Papers",
+          "url": "https://github.com/VoltAgent/awesome-ai-agent-papers",
+          "description": "Continuously updated collection of agent research papers."
+        },
+        {
+          "type": "entry",
+          "name": "Chain-of-Thought Prompting",
+          "url": "https://arxiv.org/abs/2201.11903",
+          "description": "Foundational paper on reasoning in language models."
+        },
+        {
+          "type": "entry",
+          "name": "Generative Agents",
+          "url": "https://arxiv.org/abs/2304.03442",
+          "description": "Simulating human behavior with LLM-driven agents in a sandbox."
+        },
+        {
+          "type": "entry",
+          "name": "MemGPT",
+          "url": "https://arxiv.org/abs/2310.08560",
+          "description": "OS-inspired memory management for LLM context windows."
+        },
+        {
+          "type": "entry",
+          "name": "ReAct",
+          "url": "https://arxiv.org/abs/2210.03629",
+          "description": "Synergizing reasoning and acting in language models."
+        },
+        {
+          "type": "entry",
+          "name": "Reflexion",
+          "url": "https://arxiv.org/abs/2303.11366",
+          "description": "Language agents with verbal reinforcement learning."
+        },
+        {
+          "type": "entry",
+          "name": "The Landscape of Emerging AI Agent Architectures",
+          "url": "https://arxiv.org/abs/2404.11584",
+          "description": "Survey of multi-agent design patterns."
+        },
+        {
+          "type": "entry",
+          "name": "Toolformer",
+          "url": "https://arxiv.org/abs/2302.04761",
+          "description": "Language models that learn to use tools autonomously."
+        },
+        {
+          "type": "entry",
+          "name": "Voyager",
+          "url": "https://arxiv.org/abs/2305.16291",
+          "description": "Open-ended embodied agent with LLM-powered curriculum."
+        },
+        {
+          "type": "text",
+          "text": ""
+        }
+      ]
+    },
+    {
+      "name": "Communities",
+      "items": [
+        {
+          "type": "text",
+          "text": ""
+        },
+        {
+          "type": "text",
+          "text": "Forums, Discord servers, newsletters, and social accounts."
+        },
+        {
+          "type": "text",
+          "text": ""
+        },
+        {
+          "type": "entry",
+          "name": "AI Agent Discord Servers",
+          "url": "https://discord.gg/crewai",
+          "description": "CrewAI community Discord."
+        },
+        {
+          "type": "entry",
+          "name": "Anthropic Discord",
+          "url": "https://discord.gg/anthropic",
+          "description": "Official Anthropic community."
+        },
+        {
+          "type": "entry",
+          "name": "ElizaOS Discord",
+          "url": "https://discord.gg/elizaos",
+          "description": "Community for ElizaOS agent builders."
+        },
+        {
+          "type": "entry",
+          "name": "LangChain Discord",
+          "url": "https://discord.gg/langchain",
+          "description": "LangChain developer community."
+        },
+        {
+          "type": "entry",
+          "name": "Latent Space Podcast",
+          "url": "https://www.latent.space",
+          "description": "Podcast covering AI engineering and agents."
+        },
+        {
+          "type": "entry",
+          "name": "Nous Research Discord",
+          "url": "https://discord.gg/nousresearch",
+          "description": "Community for Hermes, OpenClaw, and Nous Research agent builders."
+        },
+        {
+          "type": "entry",
+          "name": "r/artificial",
+          "url": "https://www.reddit.com/r/artificial/",
+          "description": "Subreddit for AI discussions and news."
+        },
+        {
+          "type": "entry",
+          "name": "r/LocalLLaMA",
+          "url": "https://www.reddit.com/r/LocalLLaMA/",
+          "description": "Community for local LLM deployment and agent experimentation."
+        },
+        {
+          "type": "entry",
+          "name": "Solana AI Discord",
+          "url": "https://discord.gg/solana",
+          "description": "Solana developer community with AI channels."
+        },
+        {
+          "type": "text",
+          "text": ""
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add a machine-readable catalog (`data/resources.json`) and deterministic README generator
- wire `awesome-lint` workflow to regenerate README and fail on catalog/README drift
- add section floor guardrails and PR-time cross-listing rationale checks
- update CONTRIBUTING and PR template for the catalog-first contribution flow
- expand curated entries across config, skills, security, and observability categories

## Intentional cross-listings
- `https://github.com/obra/superpowers` is intentionally listed in both "Agent Configs and Dotfiles" and "Frameworks and SDKs".
- Rationale: it is both an actionable agent config layer and a lightweight framework/tooling surface users discover via either path; duplicating improves findability for distinct maintainer/search intents.

## Validation
- python3 .github/scripts/generate_readme_from_catalog.py
- python3 .github/scripts/check_alpha_sections.py
- python3 .github/scripts/check_section_floors.py
- python3 .github/scripts/check_internal_links.py

## Why
Moves curation quality gates from manual review into repeatable CI checks, reducing drift and improving maintainer throughput.