### PR TITLE
Add Toprank to Claude Code Resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ AI agents that write, review, and debug code.
 - [CLAUDE.md Guide](https://docs.anthropic.com/en/docs/claude-code/memory) - Official documentation on memory files.
 - [claude-code-tips](https://github.com/ykdojo/claude-code-tips) - Community-sourced tips and tricks.
 - [Everything Claude Code](https://github.com/affaan-m/everything-claude-code) - Comprehensive Claude Code harness with agent skills, hooks, and multi-language support.
+- [Toprank](https://github.com/nowork-studio/toprank) - Open-source MIT Claude Code plugin with 9 SEO and Google Ads skills that connects Google Search Console, PageSpeed Insights, and the Google Ads API to ship fixes including meta tag rewrites, JSON-LD schema generation, keyword bid adjustments, and CMS content pushes.
 
 ### Codex Resources
 


### PR DESCRIPTION
## Summary
- add Toprank to `README.md` under `### Claude Code Resources`
- place it in the closest existing category to `Developer Productivity Tools`, since this list does not currently define that section
- keep the change limited to a single README entry

## Why Toprank fits
Toprank is an MIT-licensed, open-source Claude Code plugin with 178 GitHub stars and recent maintenance activity (latest push on 2026-04-09). It adds a practical Claude Code workflow around SEO and Google Ads with 9 skills, and integrates Google Search Console, PageSpeed Insights, and the Google Ads API.

Its automation scope also fits this repo's developer-tooling angle for coding agents: it can ship concrete fixes such as meta tag rewrites, JSON-LD schema generation, keyword bid adjustments, and CMS content pushes.

## Placement
This repository does not have a `Developer Productivity Tools` category. I placed Toprank under `### Claude Code Resources` as the closest existing match because that section already groups Claude Code ecosystem resources and operator tooling.
