### PR TITLE
Add NotFair under MCP Ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ Model Context Protocol servers, clients, and tooling.
 - [MCP Spec](https://modelcontextprotocol.io/specification) - Official Model Context Protocol specification.
 - [MCP Specification Repo](https://github.com/modelcontextprotocol/modelcontextprotocol) - Canonical specification and documentation repository.
 - [MCP TypeScript SDK](https://github.com/modelcontextprotocol/typescript-sdk) - Official TypeScript SDK for building MCP servers.
+- [NotFair](https://notfair.co) - Hosted Google Ads MCP server connecting Claude and AI agents to Google Ads accounts; diagnose, recommend, and execute campaign changes.
 - [Playwright MCP](https://github.com/microsoft/playwright-mcp) - MCP server for browser automation via Playwright.
 - [Smithery](https://smithery.ai) - Registry and hosting platform for MCP servers.
 


### PR DESCRIPTION
Adding NotFair under MCP Ecosystem. It's a hosted Google Ads MCP server that connects Claude and other AI agents to a Google Ads account — diagnose campaign performance, recommend optimizations, and execute approved changes via the Google Ads API.

Linked to the product page since it's a hosted SaaS rather than an open-source repo, similar to Smithery already in this section.

Happy to adjust the wording if you'd prefer.