### PR TITLE
Add TWZRD Agent Intel — Solana agent trust scoring MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,6 +374,7 @@ Tools and SDKs for building AI agents on Solana.
 - [Solana Web3.js](https://github.com/solana-labs/solana-web3.js) - JavaScript SDK for interacting with the Solana blockchain.
 - [Switchboard Solana SDK](https://github.com/switchboard-xyz/solana-sdk) - Verifiable oracle and data-feed SDK for agent decision systems.
 - [Yellowstone gRPC](https://github.com/rpcpool/yellowstone-grpc) - High-throughput real-time Solana data streams for low-latency agents and indexers.
+- [TWZRD Agent Intel](https://intel.twzrd.xyz) - MCP server for Solana agent trust scoring and on-chain receipt verification. Free tools: `resolve_agent`, `score_agent`, `preflight_check`, `verify_trust_receipt`. Paid receipt generation via x402/USDC. Zero-install: `{"mcpServers": {"twzrd-agent-intel": {"url": "https://intel.twzrd.xyz/mcp"}}}`
 - [Solana Agent Architecture Playbook (this repo)](guides/solana-agent-architecture-playbook.md) - Reference architecture, security controls, and ops checklist for production Solana agents.
 
 ## Agent Identity and Wallets
@@ -396,6 +397,7 @@ On-chain identity, wallets, and trust infrastructure for autonomous AI agents.
 - [Squads Protocol](https://github.com/Squads-Protocol/v4) - Multisig and smart account protocol for Solana agents.
 - [Turnkey](https://www.turnkey.com) - Secure key infrastructure for programmatic wallet management.
 - [UCAN](https://github.com/ucan-wg/spec) - User-controlled authorization for decentralized agent capabilities.
+- [TWZRD Agent Intel](https://intel.twzrd.xyz) - Solana-native agent trust scoring and on-chain receipt generation. Resolves agent identity from wallet address, generates signed trust receipts via x402 payment, and provides preflight verification before transactions. MCP endpoint: `https://intel.twzrd.xyz/mcp`
 
 ## Agent Payments
 


### PR DESCRIPTION
Adds [TWZRD Agent Intel](https://intel.twzrd.xyz) to two sections where it belongs:

**1. Solana Agent Infrastructure** — Trust scoring and receipt verification for Solana agents via MCP.

**2. Agent Identity and Wallets** — Resolves agent identity from Solana wallet address, generates signed on-chain trust receipts.

**What it does**:
- `resolve_agent` — resolve agent identity from wallet
- `score_agent` — get trust score for an agent
- `preflight_check` — pre-transaction trust verification
- `verify_trust_receipt` — verify an existing receipt (all free)
- `get_trust_receipt` — generate signed on-chain receipt (paid via x402/USDC)

**Zero-install** (Streamable HTTP):
```json
{"mcpServers": {"twzrd-agent-intel": {"url": "https://intel.twzrd.xyz/mcp"}}}
```

This fits directly alongside the existing x402 entries and Solana identity tools in this list.