### PR TITLE
docs: add Tree Ring Memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,6 +350,7 @@ Agent memory architectures, knowledge graphs, and second-brain integrations.
 - [ODIN](https://github.com/memgraph/odin) - Knowledge graph construction tool built on Memgraph.
 - [Pinecone](https://www.pinecone.io) - Vector database for semantic memory and retrieval.
 - [Qdrant](https://github.com/qdrant/qdrant) - High-performance vector search engine for agent memory.
+- [Tree Ring Memory](https://github.com/TerminallyLazy/Tree-Ring-Memory) - Rust-native local-first memory lifecycle framework for AI agents with SQLite/FTS recall, audit, consolidation, and forgetting.
 - [txtai](https://github.com/neuml/txtai) - All-in-one embeddings database for semantic search and workflows.
 - [Weaviate](https://github.com/weaviate/weaviate) - Vector database with built-in modules for AI workloads.
 - [Zep](https://github.com/getzep/zep) - Memory infrastructure and retrieval stack for AI assistants and agents.


### PR DESCRIPTION
## Proposed Entry

- [x] I have read the [contributing guidelines](../CONTRIBUTING.md)
- [x] The entry follows the format: `- [Name](URL) - Description.`
- [x] The description starts with a capital letter and ends with a period
- [x] The link is not a duplicate of an existing entry
- [x] The project is actively maintained
- [x] The entry is in alphabetical order within its section

## Merge + Hygiene Checklist

- [x] Branch is up to date with `main` (rebased or merged) before review
- [x] No conflict markers (`<<<<<<<`, `=======`, `>>>>>>>`) remain
- [x] CI checks pass (link check/docs health)
- [x] Scope is tight (no unrelated files or drive-by edits)

### Entry

```markdown
- [Tree Ring Memory](https://github.com/TerminallyLazy/Tree-Ring-Memory) - Rust-native local-first memory lifecycle framework for AI agents with SQLite/FTS recall, audit, consolidation, and forgetting.
```

### Section

Knowledge Graphs and Memory

### Why?

Tree Ring Memory belongs in the memory section because it gives agent builders a local-first memory lifecycle layer with recall, audit, consolidation, and forgetting rather than a transcript dump or hosted vector-only backend.

Awesome Score: Maintenance 4, Docs 4, Production 3, Unique 4, Security 3

### Local checks

- `python3 .github/scripts/check_alpha_sections.py README.md`
- `python3 .github/scripts/check_internal_links.py`
- `git diff --check`

`npx --yes awesome-lint README.md` still reports the existing repository-wide advisory baseline called out by the current workflow behavior; this PR adds only one link entry.