### PR TITLE
Add AgentServices — x402-paid APIs for AI agents (52 endpoints)

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,6 +401,7 @@ On-chain identity, wallets, and trust infrastructure for autonomous AI agents.
 
 Payment protocols and infrastructure for autonomous agent transactions.
 
+- [AgentServices](https://agentservices.to) - x402-paid API platform for AI agents with 52 endpoints covering crypto data, market intelligence, DeFi strategies, and on-chain analytics.
 - [Awesome x402](https://github.com/Merit-Systems/awesome-x402) - Curated resources for the x402 payment protocol ecosystem.
 - [Coinbase Agentic Wallets](https://www.coinbase.com/developer-platform/discover/launches/agentic-wallets) - Wallet infrastructure for AI agents with programmable spending limits.
 - [Google A2A x402 Extension](https://github.com/google-agentic-commerce/a2a-x402) - Cryptocurrency payments for the Agent-to-Agent protocol via x402.


### PR DESCRIPTION
## AgentServices — x402-Paid APIs for AI Agents

Added under **Agent Payments** section (alphabetical order).

**Website:** https://agentservices.to
**MCP Server:** https://agentservices.to/mcp (streamable-http)
**GitHub:** https://github.com/vbkotecha/aiservices-api

### What is AgentServices?
A premium API platform for AI agents. 52 endpoints covering crypto data, market intelligence, on-chain analytics, DeFi strategies, portfolio intelligence, and cross-DEX arbitrage scanning. Agents discover and pay for data services via USDC micropayments (x402) on Base mainnet.

- **40 paid endpoints** (bash.01–bash.25 per call via x402)
- **12 free endpoints** (crypto prices, fear/greed, trending, gas, news, social)
- **37 MCP tools** (remote streamable-http transport)
- **Protocol:** MCP 2026-07-28

AgentServices is one of the largest x402-native API platforms, perfectly fitting the sovereign agent stack.