### PR TITLE
Add ReMe to Knowledge Graphs and Memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,6 +350,7 @@ Agent memory architectures, knowledge graphs, and second-brain integrations.
 - [ODIN](https://github.com/memgraph/odin) - Knowledge graph construction tool built on Memgraph.
 - [Pinecone](https://www.pinecone.io) - Vector database for semantic memory and retrieval.
 - [Qdrant](https://github.com/qdrant/qdrant) - High-performance vector search engine for agent memory.
+- [ReMe](https://github.com/agentscope-ai/ReMe) - Local-first agent memory layer with editable Markdown storage and hybrid retrieval.
 - [txtai](https://github.com/neuml/txtai) - All-in-one embeddings database for semantic search and workflows.
 - [Weaviate](https://github.com/weaviate/weaviate) - Vector database with built-in modules for AI workloads.
 - [Zep](https://github.com/getzep/zep) - Memory infrastructure and retrieval stack for AI assistants and agents.


### PR DESCRIPTION
## Summary

- Add ReMe to the Knowledge Graphs and Memory section
- Describe its local-first, editable Markdown storage and hybrid retrieval

ReMe is actively maintained, documented, and provides a file-native memory layer that is distinct from the databases and hosted memory services already listed.

Awesome Score: Maintenance 5, Docs 5, Production 4, Unique 5, Security 3

## Validation

- `git diff --check`