### PR TITLE
Add Agent-Ready Repo Auditor to CLI and TUI Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ Hermes Agent runtime, deployment rails, and operator resources.
 
 Terminal-based agent interfaces and developer tools.
 
+- [Agent-Ready Repo Auditor](https://github.com/wrightops-ai/agent-ready-repo-auditor) - Dependency-free GitHub Action and Python CLI that scores immutable public repository evidence for coding-agent instructions, setup, verification, and risky-action boundaries without cloning or executing repository code.
 - [aichat](https://github.com/sigoden/aichat) - All-in-one LLM CLI with chat, shell assistant, RAG, and agent features.
 - [Claude Code](https://docs.anthropic.com/en/docs/claude-code) - Agentic CLI that operates directly in the terminal.
 - [Codex CLI](https://github.com/openai/codex) - Open-source coding agent from OpenAI.


### PR DESCRIPTION
## What this adds

Adds one alphabetized CLI and TUI Tools entry for Agent-Ready Repo Auditor, a dependency-free GitHub Action and Python CLI. The entry links only to the MIT-licensed public repository and describes verified behavior; it includes no commercial, checkout, or marketing-site link.

## Why it belongs

It helps agent builders audit whether a public repository has recognized agent instructions, setup guidance, verification commands, and risky-action boundaries at an immutable revision. It does not duplicate the listed general-purpose CLIs or agent-evaluation frameworks because it is a repository-readiness preflight and does not clone or execute target code.

Awesome Score: Maintenance 4, Docs 5, Production 3, Unique 4, Security 4

- **Maintenance 4:** Two public releases, a current main commit, and successful hosted CI.
- **Docs 5:** README, Action usage, CLI usage, scoring rubric, evidence model, limitations, and contribution guidance are public.
- **Production 3:** Thirty-four tests and hosted Python 3.10, Python 3.13, and local-Action consumer jobs pass; the project is new and has no claimed independent adoption.
- **Unique 4:** It checks immutable repository evidence for multi-harness readiness rather than acting as another coding agent or generic evaluator.
- **Security 4:** It is dependency-free, reads public GitHub evidence without cloning or executing target code, pins Action permissions read-only, and reports missing evidence rather than inventing it.

## Checks

- [x] One entry only.
- [x] Canonical URL returns HTTP 200.
- [x] No current README, issue, or pull-request duplicate found.
- [x] Alphabetical and internal-link checks pass.
- [x] Description is factual, capitalized, and ends with a period.
- [x] No price, checkout, paid-service link, or marketing site is included.

## Affiliation and assistance

I maintain the submitted project on behalf of WrightOps AI. AI assistance was used to research and prepare this contribution; I reviewed every submitted word and verified the rules, links, provenance, and claims.