### PR TITLE
Add Hermes to Voice and Multimodal Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ AI agents that write, review, and debug code.
 Agents with voice, vision, and multimodal capabilities.
 
 - [ElevenLabs](https://github.com/elevenlabs/elevenlabs-python) - Text-to-speech and voice cloning API for agent voice interfaces.
+- [Hermes](https://www.buildwithhermes.com) - White-label voice agent platform for agencies, with built-in CRM, outbound campaigns, and per-minute usage billing.
 - [LiveKit Agents](https://github.com/livekit/agents) - Framework for building real-time multimodal AI agents.
 - [Pipecat](https://github.com/pipecat-ai/pipecat) - Framework for building voice and multimodal conversational agents.
 - [TEN Framework](https://github.com/TEN-framework/ten-framework) - Open-source framework for conversational voice AI agents.


### PR DESCRIPTION
The Voice and Multimodal Agents section covers both open frameworks (Pipecat, LiveKit, Vocode) and hosted platforms (Vapi). Hermes fills a gap on the hosted side: it is the deploy-and-operate layer that sits above the voice runtime.

Where it differs from what is already listed:
- Vapi/Pipecat/LiveKit give you the voice runtime. Hermes adds the pieces you otherwise assemble yourself: contact CRM, outbound/inbound campaign orchestration, per-minute usage metering and billing, and white-label branding.
- Aimed at operators running voice agents for multiple end clients rather than at a single app integration.
- Pricing is public and usage based, from $149/mo (300 included minutes) up to $699/mo (2,000 included minutes), with per-minute overage.

Note on naming: this is unrelated to the NousResearch Hermes Agent listed under the Hermes Stack section. Different project, different vendor. Happy to name the entry "Hermes (buildwithhermes.com)" if that reads more clearly to you.

Entry inserted alphabetically in the existing list. Single line, matching the section's format.