### PR TITLE
Add AgentLayer wallet runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,7 +407,7 @@ Tools and SDKs for building AI agents on Solana.
 
 On-chain identity, wallets, and trust infrastructure for autonomous AI agents.
 
-- [AgentLayer](https://github.com/lopushok9/Agent-Layer) - Local-first wallet runtime for AI agents with x402 payments and DeFi operations; wallet material stays local and onchain writes use preview plus explicit approval.
+- [AgentLayer](https://github.com/lopushok9/Agent-Layer) - Open-source, local-first wallet for AI agents, with x402 payments and DeFi tools for Base, Solana, and Ethereum, including swaps, lending, and borrowing. Keys are stored in the macOS Keychain.
 - [Coinbase AgentKit](https://github.com/coinbase/agentkit) - Toolkit for giving AI agents programmable wallet capabilities.
 - [Crossmint](https://www.crossmint.com) - Wallet-as-a-service for agent-owned wallets and NFT minting.
 - [EIP-1271](https://eips.ethereum.org/EIPS/eip-1271) - Standard for contract wallet signature validation in dapps and agent auth flows.

--- a/README.md
+++ b/README.md
@@ -407,6 +407,7 @@ Tools and SDKs for building AI agents on Solana.
 
 On-chain identity, wallets, and trust infrastructure for autonomous AI agents.
 
+- [AgentLayer](https://github.com/lopushok9/Agent-Layer) - Local-first wallet runtime for AI agents with x402 payments and DeFi operations; wallet material stays local and onchain writes use preview plus explicit approval.
 - [Coinbase AgentKit](https://github.com/coinbase/agentkit) - Toolkit for giving AI agents programmable wallet capabilities.
 - [Crossmint](https://www.crossmint.com) - Wallet-as-a-service for agent-owned wallets and NFT minting.
 - [EIP-1271](https://eips.ethereum.org/EIPS/eip-1271) - Standard for contract wallet signature validation in dapps and agent auth flows.


### PR DESCRIPTION
## Summary

Adds AgentLayer under Agent Identity and Wallets.

AgentLayer is an open-source, local-first wallet for AI agents, with x402 payments and DeFi tools for Base, Solana, and Ethereum, including swaps, lending, and borrowing. Keys are stored in the macOS Keychain.

Awesome Score: Maintenance 4, Docs 4, Production 4, Unique 4, Security 4.

## Validation

- Ran python3 .github/scripts/check_alpha_sections.py README.md
- Ran python3 .github/scripts/check_internal_links.py README.md
- Confirmed the canonical repository URL is public and working.