### PR TITLE
Add fractal to Agent Frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Multi-agent orchestration, single-agent SDKs, and runtime frameworks.
 - [Claude Agent SDK](https://github.com/anthropics/claude-agent-sdk-python) - Official Python SDK for building agents on the Claude Code runtime.
 - [CrewAI](https://github.com/crewAIInc/crewAI) - Role-based multi-agent orchestration framework.
 - [ElizaOS](https://github.com/elizaOS/eliza) - Multi-agent simulation framework for autonomous characters.
+- [fractal](https://github.com/plasma-ai/fractal) - Runs supported coding-agent CLIs as a recursive hierarchy with per-node Git worktrees, configurable limits, persistent run state, and a live terminal UI.
 - [Google ADK](https://github.com/google/adk-python) - Agent Development Kit for building agents with Gemini.
 - [Haystack](https://github.com/deepset-ai/haystack) - LLM orchestration framework for building search and RAG pipelines.
 - [Hermes Agent](https://github.com/NousResearch/hermes-agent) - Tool-using autonomous agent platform with memory, skills, delegation, and MCP support.


### PR DESCRIPTION
## Proposed entry

- [x] I have read the [contributing guidelines](https://github.com/0xNyk/awesome-agent-cortex/blob/main/CONTRIBUTING.md)
- [x] The entry follows the format: `- [Name](URL) - Description.`
- [x] The description starts with a capital letter and ends with a period
- [x] The link is not a duplicate of an existing entry
- [x] The project is actively maintained
- [x] The entry is in alphabetical order within its section
- [x] I checked the canonical project URL rather than relying on a redirect

## Merge and hygiene checklist

- [x] Branch is up to date with `main` (rebased or merged) before review
- [x] No conflict markers (`<<<<<<<`, `=======`, `>>>>>>>`) remain
- [ ] CI checks pass (link check/docs health)
- [x] Scope is tight (no unrelated files or drive-by edits)
- [x] No credentials, personal data, private deployment details, or unrelated local paths are included

### Entry

```markdown
- [fractal](https://github.com/plasma-ai/fractal) - Runs supported coding-agent CLIs as a recursive hierarchy with per-node Git worktrees, configurable limits, persistent run state, and a live terminal UI.
```

### Section

Agent Frameworks

### Why?

fractal coordinates five coding-agent CLIs through recursive delegation. Per-node Git worktrees separate their changes, while configurable limits, persistent state, and live monitoring give operators control over the hierarchy.

Awesome Score: Maintenance 5, Docs 5, Production 3, Unique 5, Security 3

Disclosure: I am affiliated with Plasma AI, which maintains fractal.

### Evidence

- [Repository and README](https://github.com/plasma-ai/fractal)
- [Documentation](https://docs.plasma.ai/fractal)

### Intentional cross-listings

None.
