### PR TITLE
Add ClawBench to agent evaluation benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ Harnesses, benchmarks, and evaluation frameworks for measuring agent quality and
 - [AutoGen agbench](https://github.com/microsoft/autogen/blob/main/python/packages/agbench/README.md) - Benchmark runner for AutoGen agent workflows.
 - [BrowserGym](https://github.com/ServiceNow/BrowserGym) - Gym-style environment for training and evaluating browser agents.
 - [browser-use](https://github.com/browser-use/browser-use) - Framework for browser task automation and agent web interaction loops.
-- [ClawBench](https://github.com/TIGER-AI-Lab/ClawBench) - Browser-agent benchmark with 153 everyday tasks on live websites, safe final-action interception, and replay, action, network, and message traces.
+- [ClawBench](https://github.com/TIGER-AI-Lab/ClawBench) - Browser-agent benchmark with 283 tasks (V1 153 + V2 130) across 163 live websites, safe final-action interception, and replay, action, network, and message traces.
 - [Inspect AI](https://github.com/UKGovernmentBEIS/inspect_ai) - Open-source framework for reproducible LLM and agent evaluations.
 - [JailbreakBench](https://github.com/JailbreakBench/jailbreakbench) - Open robustness benchmark for measuring jailbreak resistance in language models and agents.
 - [MCPMark](https://github.com/eval-sys/mcpmark) - Stress-testing benchmark for evaluating model and agent capability on MCP tasks.

--- a/README.md
+++ b/README.md
@@ -242,6 +242,7 @@ Harnesses, benchmarks, and evaluation frameworks for measuring agent quality and
 - [AutoGen agbench](https://github.com/microsoft/autogen/blob/main/python/packages/agbench/README.md) - Benchmark runner for AutoGen agent workflows.
 - [BrowserGym](https://github.com/ServiceNow/BrowserGym) - Gym-style environment for training and evaluating browser agents.
 - [browser-use](https://github.com/browser-use/browser-use) - Framework for browser task automation and agent web interaction loops.
+- [ClawBench](https://github.com/TIGER-AI-Lab/ClawBench) - Browser-agent benchmark with 153 everyday tasks on live websites, safe final-action interception, and replay, action, network, and message traces.
 - [Inspect AI](https://github.com/UKGovernmentBEIS/inspect_ai) - Open-source framework for reproducible LLM and agent evaluations.
 - [JailbreakBench](https://github.com/JailbreakBench/jailbreakbench) - Open robustness benchmark for measuring jailbreak resistance in language models and agents.
 - [MCPMark](https://github.com/eval-sys/mcpmark) - Stress-testing benchmark for evaluating model and agent capability on MCP tasks.


### PR DESCRIPTION
## Proposed entry

- [x] I have read the contributing guidelines
- [x] The entry follows `- [Name](URL) - Description.`
- [x] The description starts with a capital letter and ends with a period
- [x] The URL and project name are not already present
- [x] The project is active, documented, and alphabetized in its section
- [x] The URL is the canonical TIGER-AI-Lab repository, not a redirect

### Entry

```markdown
- [ClawBench](https://github.com/TIGER-AI-Lab/ClawBench) - Browser-agent benchmark with 283 tasks (V1 153 + V2 130) across 163 live websites, safe final-action interception, and replay, action, network, and message traces.
```

### Section

Agent Harnessing and Evaluation → Benchmark Reality Check (real-world tool use)

### Why?

The entry gives agent builders a reproducible live-web benchmark with both outcome evaluation and inspectable execution evidence. Its description is factual and limited to capabilities documented by the project.

Awesome Score: Maintenance 5, Docs 5, Production 4, Unique 5, Security 4

### Evidence

- Canonical repository: https://github.com/TIGER-AI-Lab/ClawBench
- Paper: https://arxiv.org/abs/2604.08523

### Local checks

- `python3 .github/scripts/check_alpha_sections.py README.md` — 27 curated blocks OK
- `python3 .github/scripts/check_internal_links.py` — 56 Markdown files OK
- `git diff --check origin/main...HEAD`

No intentional cross-listing is proposed.

Disclosure: I am a ClawBench maintainer. I have identified that affiliation explicitly so the maintainers can assess this one-entry proposal with full context.