### PR TITLE
docs: add ClawBench to agent benchmarking resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,7 @@ Harnesses, benchmarks, and evaluation frameworks for measuring agent quality and
 - [AutoGen agbench](https://github.com/microsoft/autogen/blob/main/python/packages/agbench/README.md) - Benchmark runner for AutoGen agent workflows.
 - [BrowserGym](https://github.com/ServiceNow/BrowserGym) - Gym-style environment for training and evaluating browser agents.
 - [browser-use](https://github.com/browser-use/browser-use) - Framework for browser task automation and agent web interaction loops.
+- [ClawBench](https://github.com/TIGER-AI-Lab/ClawBench) - Open-source benchmark for browser AI agents on daily tasks, with isolated environments and multi-layer trajectory capture.
 - [Inspect AI](https://github.com/UKGovernmentBEIS/inspect_ai) - Open-source framework for reproducible LLM and agent evaluations.
 - [JailbreakBench](https://github.com/JailbreakBench/jailbreakbench) - Open robustness benchmark for measuring jailbreak resistance in language models and agents.
 - [MCPMark](https://github.com/eval-sys/mcpmark) - Stress-testing benchmark for evaluating model and agent capability on MCP tasks.


### PR DESCRIPTION
## Proposed entry

- [x] I have read the [contributing guidelines](../CONTRIBUTING.md)
- [x] The entry follows the required format
- [x] The link is not a duplicate of an existing entry
- [x] The project is actively maintained
- [x] The entry is in alphabetical order within its section
- [x] I checked the canonical project URL

### Entry

```markdown
- [ClawBench](https://github.com/TIGER-AI-Lab/ClawBench) - Open-source benchmark for browser AI agents on daily tasks, with isolated environments and multi-layer trajectory capture.
```

### Section

Agent Harnessing and Evaluation → Benchmark Reality Check (real-world tool use)

### Why?

ClawBench is a maintained, documented benchmark for browser agents operating across daily websites. It is directly relevant to this section alongside BrowserGym, OSWorld, and WebArena.

### Evidence

Primary repository: https://github.com/TIGER-AI-Lab/ClawBench

I am submitting as a ClawBench maintainer (reacher-z, mtrxcop@gmail.com). AI assistance was used for drafting and checklist verification; I verified the repository link, activity, and description.