### PR TITLE
Add Hivekeep to Agent Frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Multi-agent orchestration, single-agent SDKs, and runtime frameworks.
 - [Google ADK](https://github.com/google/adk-python) - Agent Development Kit for building agents with Gemini.
 - [Haystack](https://github.com/deepset-ai/haystack) - LLM orchestration framework for building search and RAG pipelines.
 - [Hermes Agent](https://github.com/NousResearch/hermes-agent) - Tool-using autonomous agent platform with memory, skills, delegation, and MCP support.
+- [Hivekeep](https://github.com/MarlBurroW/hivekeep) - Self-hosted platform to run a team of specialized AI agents with persistent memory, a web UI, and chat channels.
 - [Julep](https://github.com/julep-ai/julep) - Stateful agent platform with built-in persistence and task workflows.
 - [LangChain](https://github.com/langchain-ai/langchain) - Composable framework for building LLM-powered applications.
 - [LangGraph](https://github.com/langchain-ai/langgraph) - Library for building stateful multi-agent workflows as graphs.


### PR DESCRIPTION
Adds **Hivekeep** to the Agent Frameworks section (alphabetical, after Hermes Agent).

Hivekeep is a self-hosted, MIT-licensed platform to run a team of specialized AI agents with persistent memory and a web UI; agents collaborate and build their own tools, mini-apps and plugins; reachable over Telegram, Slack, Discord and Matrix; single container (Bun + SQLite).

Awesome Score: Maintenance 4, Docs 4, Production 3, Unique 4, Security 3

Disclosure: I am the author of Hivekeep.