### PR TITLE
docs: add Suede Creator Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,7 +357,7 @@ Hands-on resources for designing, testing, and shipping high-quality agent skill
 - [Claude Skills Quickstart Checklist (this repo)](guides/claude-skills-quickstart-checklist.md) - Build-test-ship checklist for repeatable skill quality.
 - [NVIDIA Agent Skills](https://github.com/NVIDIA/skills) - NVIDIA-maintained catalog of skills for CUDA-X libraries, blueprints, and platform tools.
 - [SkillsBench](https://github.com/benchflow-ai/skillsbench) - Benchmark for measuring how agents use skill packages across verifiable tasks.
-- [Suede Creator Skills](https://github.com/JasonColapietro/suede-creator-skills) - MIT-licensed collection of 67 Claude Code and Codex skills for orchestration, worker fleets, code review, AI evaluation, product, design, and growth workflows.
+- [Suede Creator Skills](https://github.com/JasonColapietro/suede-creator-skills) - MIT-licensed collection of 71 Claude Code and Codex skills for orchestration, worker fleets, code review, AI evaluation, product, design, and growth workflows.
 
 ## Knowledge Graphs and Memory
 

--- a/README.md
+++ b/README.md
@@ -357,6 +357,7 @@ Hands-on resources for designing, testing, and shipping high-quality agent skill
 - [Claude Skills Quickstart Checklist (this repo)](guides/claude-skills-quickstart-checklist.md) - Build-test-ship checklist for repeatable skill quality.
 - [NVIDIA Agent Skills](https://github.com/NVIDIA/skills) - NVIDIA-maintained catalog of skills for CUDA-X libraries, blueprints, and platform tools.
 - [SkillsBench](https://github.com/benchflow-ai/skillsbench) - Benchmark for measuring how agents use skill packages across verifiable tasks.
+- [Suede Creator Skills](https://github.com/JasonColapietro/suede-creator-skills) - MIT-licensed collection of 67 Claude Code and Codex skills for orchestration, worker fleets, code review, AI evaluation, product, design, and growth workflows.
 
 ## Knowledge Graphs and Memory
 


### PR DESCRIPTION
## Proposed entry

- [x] I have read the contributing guidelines
- [x] The entry follows the format: `- [Name](URL) - Description.`
- [x] The description starts with a capital letter and ends with a period
- [x] The link is not a duplicate of an existing entry
- [x] The project is actively maintained
- [x] The entry is in alphabetical order within its section
- [x] I checked the canonical project URL rather than relying on a redirect

## Merge and hygiene checklist

- [x] Branch is up to date with `main` before review
- [x] No conflict markers remain
- [ ] CI checks pass
- [x] Scope is tight with no unrelated edits
- [x] No credentials, personal data, private deployment details, or unrelated local paths are included

## Summary

Add Suede Creator Skills to Skill Engineering and Playbooks.

## Entry

```markdown
- [Suede Creator Skills](https://github.com/JasonColapietro/suede-creator-skills) - MIT-licensed collection of 71 Claude Code and Codex skills for orchestration, worker fleets, code review, AI evaluation, product, design, and growth workflows.
```

## Section

Skill Engineering and Playbooks.

## Why

The project is actively maintained, documented, MIT-licensed, and offers a distinct mix of engineering controls and product workflows.

Awesome Score: Maintenance 5, Docs 5, Production 4, Unique 4, Security 4.

## Evidence

https://github.com/JasonColapietro/suede-creator-skills

## Testing

- `python3 .github/scripts/check_alpha_sections.py README.md`
- `python3 .github/scripts/check_internal_links.py`
- Verified the source and deep skill links resolve.

## Scope

One README entry only.

## Risks

The public skill count can change over time. The description reflects the source repository on 2026-08-12.

## Intentional cross-listings

None.