### PR TITLE
Add Orkas to agent frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Multi-agent orchestration, single-agent SDKs, and runtime frameworks.
 - [OpenAI Agents SDK for Python](https://github.com/openai/openai-agents-python) - Official Python SDK for agent workflows, tools, handoffs, and guardrails.
 - [OpenAI Agents SDK for TypeScript](https://github.com/openai/openai-agents-js) - Official TypeScript SDK for agent workflows and voice agents.
 - [OpenClaw](https://github.com/openclaw/openclaw) - Self-hosted personal AI agent with multi-platform messaging and skill registry.
+- [Orkas](https://github.com/Orkas-AI/Orkas) - Local-first desktop runtime where a Commander coordinates specialist agents through one chat.
 - [PydanticAI](https://github.com/pydantic/pydantic-ai) - Type-safe agent framework built around Pydantic.
 - [Rig](https://github.com/0xPlaygrounds/rig) - Rust framework for building LLM-powered applications.
 - [Semantic Kernel](https://github.com/microsoft/semantic-kernel) - SDK for integrating LLMs into apps with plugin architecture.


### PR DESCRIPTION
## Summary

- add Orkas alphabetically to Agent Frameworks
- link the canonical GitHub repository
- describe its Commander-coordinated desktop agent runtime without promotional claims

Awesome Score: Maintenance 5, Docs 4, Production 4, Unique 4, Security 3

## Verification

- confirmed there was no existing Orkas entry
- `python3 .github/scripts/check_alpha_sections.py README.md`
- `python3 .github/scripts/check_internal_links.py`
- `git diff --check`