### PR TITLE
Add Hexis to the MCP ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ Open protocols, SDKs, servers, clients, and registries for connecting agents to 
 - [Context7 MCP](https://github.com/upstash/context7) - MCP server that retrieves current, version-specific library documentation.
 - [FastMCP](https://github.com/PrefectHQ/fastmcp) - Pythonic framework for building MCP servers and clients quickly.
 - [GitHub MCP Server](https://github.com/github/github-mcp-server) - Official MCP server for GitHub workflows and repository actions.
+- [Hexis](https://github.com/Bevel-Software/Hexis) - Git-backed platform for managing skills, tools, and context for AI agents, with review workflows, role-based access, and a remote MCP server.
 - [MCP Agent](https://github.com/lastmile-ai/mcp-agent) - Framework patterns for building agents on top of MCP.
 - [MCP for Beginners](https://github.com/microsoft/mcp-for-beginners) - Cross-language curriculum and practical examples for learning MCP.
 - [MCP Go SDK](https://github.com/mark3labs/mcp-go) - Go implementation of the Model Context Protocol.


### PR DESCRIPTION
Adds Hexis to Agent Protocols and MCP Ecosystem.

Entry: Hexis is a Git-backed platform for managing skills, tools, and context for AI agents, with review workflows, role-based access, and a remote MCP server.

Why: It gives teams one reviewable source for the context and capabilities that agents consume over MCP.

Evidence: https://github.com/Bevel-Software/Hexis

Awesome Score: Maintenance 5, Docs 5, Production 3, Unique 4, Security 4

I work on Hexis.