### PR TITLE
Add stipend to Agent Payments

### DIFF
--- a/README.md
+++ b/README.md
@@ -434,6 +434,7 @@ Payment protocols and infrastructure for autonomous agent transactions.
 - [lobster.cash](https://www.lobster.cash) - Agent payment solution on Solana with Visa Intelligent Commerce integration by Crossmint.
 - [Request Network](https://request.network) - Crypto-native invoicing and payment request rails for agent billing workflows.
 - [Solana Pay](https://solanapay.com) - Open payments standard for Solana-based checkout and transfer flows.
+- [stipend](https://github.com/stipend-sh/stipend) - Non-custodial USDC wallet on Base with per-transaction, per-day and per-counterparty spending limits enforced in the signing path, plus buyer-side x402 auto-pay and a local stdio MCP server.
 - [Superfluid](https://superfluid.org) - Streaming payment primitives for machine-to-machine and agent subscriptions.
 - [x402 Foundation](https://www.x402.org) - Open protocol foundation governing the x402 payment standard.
 - [x402 Protocol](https://github.com/coinbase/x402) - Open HTTP payment protocol using the 402 status code for agent-to-service payments.


### PR DESCRIPTION
One entry in **Agent Payments**, placed alphabetically between Solana Pay and Superfluid.

```markdown
- [stipend](https://github.com/stipend-sh/stipend) - Non-custodial USDC wallet on Base with per-transaction, per-day and per-counterparty spending limits enforced in the signing path, plus buyer-side x402 auto-pay and a local stdio MCP server.
```

Against the rules: one entry, capital start and full stop, no articles at the start, no trailing slash, canonical URL, alphabetical.

**Distinct value** (rule 10 of "what we look for): the other wallet entries here put the spending decision in the model's hands or behind a hosted account. stipend's caps and destination allowlist are enforced in [`policy.py`](https://github.com/stipend-sh/stipend/blob/main/stipend/policy.py), between the agent deciding to pay and the transaction being signed, so no wording in a context window can raise them — which is the failure mode that matters for an agent holding money.

**Maintenance and documentation:** active daily commits, Apache-2.0, README documents the seven MCP tools, the stdio transport and a client config; agent-facing docs at https://stipend.sh/skill.md.

**Stated rather than hidden:** the repo is new (first commit 2026-08-08), and **it has not been audited**. If the newness puts it below your scoring bar, that is a fair reason to decline.
