### PR TITLE
Add LWC to Knowledge Graphs and Memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,6 +369,7 @@ Agent memory architectures, knowledge graphs, and second-brain integrations.
 - [Khoj](https://github.com/khoj-ai/khoj) - Personal AI assistant with long-term memory and knowledge search.
 - [LangMem](https://github.com/langchain-ai/langmem) - Memory management toolkit for building long-horizon agent systems.
 - [LightRAG](https://github.com/HKUDS/LightRAG) - Simple and fast RAG framework using graph structures.
+- [LWC](https://github.com/JanYork/llm-wiki-cli) - Source-grounded project memory for coding agents with SQLite full-text retrieval, optional document and code graphs, lifecycle hooks, and a bounded read-only MCP interface.
 - [Mem0](https://github.com/mem0ai/mem0) - Memory layer for AI assistants and agents.
 - [Memgraph](https://github.com/memgraph/memgraph) - In-memory graph database for real-time agent queries.
 - [Neo4j](https://github.com/neo4j/neo4j) - Graph database platform widely used for agent knowledge stores.


### PR DESCRIPTION
## Proposed entry

- [x] I have read the [contributing guidelines](https://github.com/0xNyk/awesome-agent-cortex/blob/main/CONTRIBUTING.md)
- [x] The entry follows the required format
- [x] The description starts with a capital letter and ends with a period
- [x] The link is not a duplicate of an existing entry
- [x] The project is actively maintained
- [x] The entry is in alphabetical order within its section
- [x] I checked the canonical project URL rather than relying on a redirect

## Merge and hygiene checklist

- [x] Branch is based on current `main`
- [x] No conflict markers remain
- [x] Repository checks pass locally
- [x] Scope is one README entry only
- [x] No credentials, personal data, private paths, or unrelated details are included

### Entry

```markdown
- [LWC](https://github.com/JanYork/llm-wiki-cli) - Source-grounded project memory for coding agents with SQLite full-text retrieval, optional document and code graphs, lifecycle hooks, and a bounded read-only MCP interface.
```

### Section

Knowledge Graphs and Memory

### Why?

LWC provides a documented, actively maintained memory system rather than a storage primitive alone. Its canonical SQLite/Markdown knowledge layer preserves sources, citations, provenance, and atomic changesets; optional document and code graphs add relationship-aware retrieval.

Awesome Score: Maintenance 5, Docs 5, Production 4, Unique 5, Security 4

### Evidence

- Project and documentation: https://github.com/JanYork/llm-wiki-cli
- Security policy: https://github.com/JanYork/llm-wiki-cli/blob/main/SECURITY.md

### Intentional cross-listings

None.

Local maintainer checks passed:
- `python3 .github/scripts/check_alpha_sections.py README.md`
- `python3 .github/scripts/check_internal_links.py`
- `git diff --check`