### PR TITLE
Add OpenSkill paper

### DIFF
--- a/README.md
+++ b/README.md
@@ -503,6 +503,7 @@ Curated papers on AI agents, multi-agent systems, and agent infrastructure.
 - [Chain-of-Thought Prompting](https://arxiv.org/abs/2201.11903) - Foundational paper on reasoning in language models.
 - [Generative Agents](https://arxiv.org/abs/2304.03442) - Simulating human behavior with LLM-driven agents in a sandbox.
 - [MemGPT](https://arxiv.org/abs/2310.08560) - OS-inspired memory management for LLM context windows.
+- [OpenSkill](https://arxiv.org/abs/2606.06741) - Open-world self-evolution method where agents derive skills and verification signals without target-task supervision.
 - [ReAct](https://arxiv.org/abs/2210.03629) - Synergizing reasoning and acting in language models.
 - [Reflexion](https://arxiv.org/abs/2303.11366) - Language agents with verbal reinforcement learning.
 - [The Landscape of Emerging AI Agent Architectures](https://arxiv.org/abs/2404.11584) - Survey of multi-agent design patterns.


### PR DESCRIPTION
## Summary

Add the OpenSkill paper to the Research Papers section. OpenSkill studies open-world agent self-evolution: it derives both reusable skills and its own verification signals without target-task supervision.

This links only the canonical arXiv record. The project repository currently says its implementation is forthcoming, so the entry does not claim released code.

Awesome Score: Maintenance 4, Docs 4, Production 3, Unique 5, Security 3

## Checks

- searched the default branch and all issues/PRs for `OpenSkill`, arXiv `2606.06741`, the official repository, and the project page; no existing entry or proposal was found
- `python3 .github/scripts/check_alpha_sections.py README.md`
- `python3 .github/scripts/check_internal_links.py`
- `git diff --check`

I am submitting this on behalf of paper co-author Yuxuan Zhang.