### PR TITLE
Add Agon to Agent Frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Multi-agent orchestration, single-agent SDKs, and runtime frameworks.
 
 - [AG2](https://github.com/ag2ai/ag2) - Open-source AgentOS for building multi-agent systems (evolved from AutoGen).
 - [Agno](https://github.com/agno-agi/agno) - Framework for building and running agentic software at scale.
+- [Agon](https://github.com/AutoResearch-Factory/Agon) - Autonomous research orchestrator. Runs generate-critique loops across 10+ disciplines with 18 reusable roles and 230.6 KiB of prompts; sustained a 30-day unattended run.
 - [AutoGen](https://github.com/microsoft/autogen) - Multi-agent conversation framework from Microsoft Research.
 - [Claude Agent SDK](https://github.com/anthropics/claude-agent-sdk-python) - Official Python SDK for building agents on the Claude Code runtime.
 - [CrewAI](https://github.com/crewAIInc/crewAI) - Role-based multi-agent orchestration framework.


### PR DESCRIPTION
## Proposed entry

- [x] I have read the [contributing guidelines](https://github.com/0xNyk/awesome-agent-cortex/blob/main/CONTRIBUTING.md)
- [x] The entry follows the required format
- [x] The description starts with a capital letter and ends with a period
- [x] The link is not a duplicate of an existing entry
- [x] The project is actively maintained
- [x] The entry is in alphabetical order within its section
- [x] I checked the canonical project URL rather than relying on a redirect

## Merge and hygiene checklist

- [x] Branch is based on the current `main`
- [x] No conflict markers remain
- [x] Repository checks pass locally
- [x] Scope is one README entry only
- [x] No credentials, personal data, private paths, or unrelated details are included

### Entry

```markdown
- [Agon](https://github.com/AutoResearch-Factory/Agon) - Autonomous research orchestrator. Runs generate-critique loops across 10+ disciplines with 18 reusable roles and 230.6 KiB of prompts; sustained a 30-day unattended run.
```

### Section

Agent Frameworks

### Why?

Agon is an actively maintained, MIT-licensed Claude Code plugin for autonomous research workflows. Its documentation covers the multi-agent generation and critique loop, reusable specialist roles, and the reported unattended research run. This is the Agon half of #45, split at the maintainer's request.

Awesome Score: Maintenance 5, Docs 4, Production 3, Unique 5, Security 3

### Evidence

- Canonical repository: https://github.com/AutoResearch-Factory/Agon
- Project page: https://haizhaoyang.github.io/research/autoresearch.html
- Paper: https://arxiv.org/abs/2606.24177

### Intentional cross-listings

None.

### Local checks

- `python .github/scripts/check_alpha_sections.py README.md` — 27 curated blocks OK
- `python .github/scripts/check_internal_links.py` — 56 Markdown files OK
- `git diff --check`
