### PR TITLE
Add Herbert to Agent Configs and Dotfiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,6 +351,7 @@ Configuration files and workflow examples for AI coding tools.
 - [Cursor Starter Configs](cursorrules/) - Ready-to-use .cursorrules and rule files for Cursor projects.
 - [CursorDirectory](https://cursor.directory) - Community-shared Cursor rules and configurations.
 - [dotfiles](https://dotfiles.github.io) - Guide to managing dotfiles including agent configurations.
+- [Herbert](https://github.com/robertaustinbell/herbert) - Runtime-neutral template for building a personal AI agent with explicit identity, judgment, memory, authority boundaries, and verified-action requirements.
 - [Trail of Bits Claude Code Config](https://github.com/trailofbits/claude-code-config) - Opinionated Claude Code defaults and workflows from a security-focused engineering team.
 
 ## Skill Engineering and Playbooks


### PR DESCRIPTION
## Proposed entry

- [x] I have read the [contributing guidelines](https://github.com/0xNyk/awesome-agent-cortex/blob/main/CONTRIBUTING.md)
- [x] The entry follows the required format
- [x] The description starts with a capital letter and ends with a period
- [x] The link is not a duplicate of an existing entry
- [x] The project is actively maintained
- [x] The entry is in alphabetical order within its section
- [x] I checked the canonical project URL rather than relying on a redirect

## Merge and hygiene checklist

- [x] Branch is based on current `main`
- [x] No conflict markers remain
- [x] Repository checks pass locally
- [x] Scope is one README entry only
- [x] No credentials, personal data, private paths, or unrelated details are included

### Entry

```markdown
- [Herbert](https://github.com/robertaustinbell/herbert) - Runtime-neutral template for building a personal AI agent with explicit identity, judgment, memory, authority boundaries, and verified-action requirements.
```

### Section

Agent Configs and Dotfiles

### Why?

Herbert provides a documented architecture for personal agents rather than a vendor-specific runtime or finished personality. It separates identity, operating judgment, procedures, evidence, memory, and authority, and includes conservative adoption guidance, deterministic validation, security boundaries, and portable agent skills.

Awesome Score: Maintenance 4, Docs 5, Production 3, Unique 4, Security 4

### Evidence

- Project and documentation: https://github.com/robertaustinbell/herbert
- Security policy: https://github.com/robertaustinbell/herbert/blob/main/SECURITY.md
- Adoption guide: https://github.com/robertaustinbell/herbert/blob/main/ADOPT.md
- Validation workflow: https://github.com/robertaustinbell/herbert/blob/main/.github/workflows/validate.yml

### Intentional cross-listings

None.

Local maintainer checks passed:
- `python3 .github/scripts/check_alpha_sections.py README.md`
- `python3 .github/scripts/check_internal_links.py`
- `git diff --check`

Herbert validation also passed locally: 184 tests plus the repository template check.