### PR TITLE
Add Famulor Assistants & History Skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ Open protocols, SDKs, servers, clients, and registries for connecting agents to 
 - [Awesome MCP Servers](https://github.com/punkpeye/awesome-mcp-servers) - Curated list of MCP server implementations.
 - [Chrome DevTools MCP](https://github.com/ChromeDevTools/chrome-devtools-mcp) - Official Chrome DevTools MCP server for coding and browser automation agents.
 - [Context7 MCP](https://github.com/upstash/context7) - MCP server that retrieves current, version-specific library documentation.
-- [Famulor Skill](https://github.com/bekservice/Famulor-Skill) - Agent Skill and plugin manifest bundle for operating voice assistants, calls, messaging, knowledge, dashboards, and automations through Famulor's OAuth-protected remote MCP server.
+- [Famulor Assistants & History Skill](https://github.com/bekservice/Famulor-Skill/tree/main/claude-store/skills/famulor-assistants-history) - Read-only Agent Skill for reviewing assistant configurations and omnichannel interaction history through Famulor's restricted OAuth-protected MCP profile.
 - [FastMCP](https://github.com/PrefectHQ/fastmcp) - Pythonic framework for building MCP servers and clients quickly.
 - [GitHub MCP Server](https://github.com/github/github-mcp-server) - Official MCP server for GitHub workflows and repository actions.
 - [Hexis](https://github.com/Bevel-Software/Hexis) - Git-backed platform for managing skills, tools, and context for AI agents, with review workflows, role-based access, and a remote MCP server.

--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ Open protocols, SDKs, servers, clients, and registries for connecting agents to 
 - [Awesome MCP Servers](https://github.com/punkpeye/awesome-mcp-servers) - Curated list of MCP server implementations.
 - [Chrome DevTools MCP](https://github.com/ChromeDevTools/chrome-devtools-mcp) - Official Chrome DevTools MCP server for coding and browser automation agents.
 - [Context7 MCP](https://github.com/upstash/context7) - MCP server that retrieves current, version-specific library documentation.
+- [Famulor Skill](https://github.com/bekservice/Famulor-Skill) - Agent Skill and plugin manifest bundle for operating voice assistants, calls, messaging, knowledge, dashboards, and automations through Famulor's OAuth-protected remote MCP server.
 - [FastMCP](https://github.com/PrefectHQ/fastmcp) - Pythonic framework for building MCP servers and clients quickly.
 - [GitHub MCP Server](https://github.com/github/github-mcp-server) - Official MCP server for GitHub workflows and repository actions.
 - [Hexis](https://github.com/Bevel-Software/Hexis) - Git-backed platform for managing skills, tools, and context for AI agents, with review workflows, role-based access, and a remote MCP server.


### PR DESCRIPTION
## Proposed entry

- [Famulor Assistants & History Skill](https://github.com/bekservice/Famulor-Skill/tree/main/claude-store/skills/famulor-assistants-history) - Read-only Agent Skill for reviewing assistant configurations and omnichannel interaction history through Famulor's restricted OAuth-protected MCP profile.

## Section

Agent Protocols and MCP Ecosystem

## Why?

The deep-linked public `SKILL.md` gives agents a bounded workflow for 11 read-only list/get tools. It can review assistant configurations, versions, catalogs, and tenant-scoped call, messaging, and email history without create, update, delete, send, call, purchase, campaign, telephony, billing, or configuration actions.

## Evidence

- Skill source: https://github.com/bekservice/Famulor-Skill/tree/main/claude-store/skills/famulor-assistants-history
- Restricted MCP endpoint: https://app.famulor.io/mcp?profile=assistant-history
- OAuth scopes: `assistants:read`, `calls:read`

Awesome Score: Maintenance 5, Docs 4, Production 4, Unique 4, Security 4

I maintain Famulor; this is a first-party submission. The linked skill repository is MIT-licensed. The separate hosted MCP server is proprietary/source-available, and this PR makes no MIT/open-source claim for it.

## Checklist

- [x] The deep link works and is canonical
- [x] The entry follows the required one-line format
- [x] No duplicate Famulor entry or PR exists
- [x] The project is actively maintained and documented
- [x] The entry is alphabetically placed
- [x] Scope is one README entry with no unrelated changes

## Validation

- `python3 .github/scripts/check_alpha_sections.py README.md` — passed (27 blocks)
- `python3 .github/scripts/check_internal_links.py` — passed (56 Markdown files)
- `git diff --check` — passed
- Skill source and endpoint checks — passed